### PR TITLE
Add new source dockerDigest

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This source will check a docker image tag from a docker registry and return its 
 
 ```
 source:
-  kind: dockerTag
+  kind: dockerDigest
   spec:
     image: "Docker Image"
     url: "Docker registry url"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,7 +64,7 @@ func run(cfg string) {
 		files, err := dir.Readdirnames(-1)
 		fmt.Printf("Files: %v \n", files)
 		for _, file := range files {
-			run(filepath.Join(cfg,file))
+			run(filepath.Join(cfg, file))
 		}
 	} else {
 		fmt.Printf("Reading: %v \n", cfg)
@@ -86,6 +86,17 @@ func engine(cfgFile string) error {
 	case "githubRelease":
 		fmt.Printf("\tgithubRelease specified\n")
 		var spec github.Github
+		err := mapstructure.Decode(conf.Source.Spec, &spec)
+
+		if err != nil {
+			panic(err)
+		}
+
+		conf.Source.Output = spec.GetVersion()
+
+	case "dockerDigest":
+		fmt.Printf("\tdockerDigest specified\n")
+		var spec docker.Docker
 		err := mapstructure.Decode(conf.Source.Spec, &spec)
 
 		if err != nil {

--- a/pkg/docker/main_test.go
+++ b/pkg/docker/main_test.go
@@ -1,0 +1,58 @@
+package docker
+
+import "testing"
+
+func TestIsPublished(t *testing.T) {
+	// Test if existing image tag return true
+	d := &Docker{
+		URL:   "hub.docker.com",
+		Tag:   "latest",
+		Image: "olblak/updatecli",
+	}
+
+	got := d.IsTagPublished()
+	expected := true
+	if got != expected {
+		t.Errorf("%v:%v is published! expected %v, got %v", d.Image, d.Tag, expected, got)
+	}
+
+	// Test if none existing image tag return false
+	d = &Docker{
+		URL:   "hub.docker.com",
+		Tag:   "donotexist",
+		Image: "olblak/updatecli",
+	}
+
+	got = d.IsTagPublished()
+	expected = false
+	if got != expected {
+		t.Errorf("%v:%v is not published! expected %v, got %v", d.Image, d.Tag, expected, got)
+	}
+
+}
+
+func TestGetVersion(t *testing.T) {
+	// Test if existing return the correct digest
+	d := &Docker{
+		URL:   "hub.docker.com",
+		Tag:   "latest",
+		Image: "olblak/updatecli",
+	}
+	got := d.GetVersion()
+	expected := "sha256:535c6eda6ce32e8c3309878bd27faa0cd41c0cb833149bf5544c7bccff817541"
+	if got != expected {
+		t.Errorf("Digest expected %v, got %v", expected, got)
+	}
+
+	// Test if non existing tag return empty string
+	d = &Docker{
+		URL:   "hub.docker.com",
+		Tag:   "donotexist",
+		Image: "olblak/updatecli",
+	}
+	got = d.GetVersion()
+	expected = ""
+	if got != expected {
+		t.Errorf("Digest expected %v, got %v", expected, got)
+	}
+}


### PR DESCRIPTION
This new source retrieve a docker image digest and can be configured as the following example

```
source:
  kind: dockerDigest
    spec:
      image: "jenkinsciinfra/plugin-site"
      url: "hub.docker.com"
      tag: latest
```

Closes #16 