### PR TITLE
Refactor engine workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ docker.run:
 	docker run -i -t --rm --name updateCli $(DOCKER_IMAGE):$(DOCKER_TAG) --help
 docker.test:
 	docker run -i -t \
-		-v $$PWD/updateCli.yaml:/home/updatecli/updateCli.yaml:ro \
-		olblak/updatecli:latest --config /home/updatecli/updateCli.yaml
+		-v $$PWD/updateCli.d:/home/updatecli/updateCli.d:ro \
+		olblak/updatecli:latest --config /home/updatecli/updateCli.d/pluginsite-api.yaml
 
 docker.push:
 	docker push $(DOCKER_IMAGE):$(DOCKER_TAG)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ conditions:
 ```
 
 ### Maven
-This conditon checks if a specific version, returned by the source, is published on a maven repository
+This condition checks if a specific version, returned by the source, is published on a maven repository
 
 ```
 condition:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,7 +71,7 @@ func run(cfg string) {
 	} else {
 		err := engine(cfg)
 		if err != nil {
-			fmt.Printf("\n\u26A0 %s \n", err)
+			fmt.Printf("\n\u26A0 %s \n\n", err)
 		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,4 +67,6 @@ func run(cfg string) {
 			fmt.Printf("\n\u26A0 %s \n\n", err)
 		}
 	}
+
+	fmt.Printf("\n\n")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -134,8 +134,12 @@ func engine(cfgFile string) error {
 
 	conf.Source.Output = conf.Source.Prefix + output + conf.Source.Postfix
 
-	fmt.Printf("\n\n%s:\n", strings.ToTitle("conditions"))
-	fmt.Printf("%s\n\n", strings.Repeat("=", len("conditions")+1))
+	if len(conf.Conditions) > 0 {
+
+		fmt.Printf("\n\n%s:\n", strings.ToTitle("conditions"))
+		fmt.Printf("%s\n\n", strings.Repeat("=", len("conditions")+1))
+
+	}
 
 	for _, condition := range conf.Conditions {
 		switch condition.Kind {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -190,7 +190,10 @@ func engine(cfgFile string) error {
 				fmt.Println(err)
 			}
 
-			spec.Update(conf.Source.Output)
+			err = spec.Update(conf.Source.Output)
+			if err != nil {
+				return err
+			}
 
 		default:
 			fmt.Printf("⚠ Don't support target: %v\n", target.Kind)

--- a/pkg/config/main.go
+++ b/pkg/config/main.go
@@ -6,45 +6,24 @@ import (
 	"strings"
 
 	"github.com/spf13/viper"
+
+	"github.com/olblak/updateCli/pkg/engine/condition"
+	"github.com/olblak/updateCli/pkg/engine/source"
+	"github.com/olblak/updateCli/pkg/engine/target"
 )
 
 // Config contains cli configuration
 type Config struct {
-	Source     Source
-	Conditions map[string]Condition
-	Targets    map[string]Target
-}
-
-// Source defines how a value is retrieved from a specific source
-type Source struct {
-	Kind    string
-	Output  string
-	Prefix  string
-	Postfix string
-	Spec    interface{}
-}
-
-// Condition defines which condition needs to be met
-// in order to update targets based on the source output
-type Condition struct {
-	Name string
-	Kind string
-	Spec interface{}
-}
-
-// Target defines which file need to be updated based on source output
-type Target struct {
-	Name       string
-	Kind       string
-	Spec       interface{}
-	Repository interface{}
+	Source     source.Source
+	Conditions map[string]condition.Condition
+	Targets    map[string]target.Target
 }
 
 // Reset reset configuration
 func (config *Config) Reset() {
-	config.Source = Source{}
-	config.Conditions = map[string]Condition{}
-	config.Targets = map[string]Target{}
+	config.Source = source.Source{}
+	config.Conditions = map[string]condition.Condition{}
+	config.Targets = map[string]target.Target{}
 }
 
 // ReadFile reads the updatecli configuration file

--- a/pkg/docker/main.go
+++ b/pkg/docker/main.go
@@ -42,12 +42,11 @@ func (d *Docker) Check() (bool, error) {
 	return true, nil
 }
 
-// IsTagPublished checks if a docker image with a specific tag is published
-func (d *Docker) IsTagPublished() bool {
+// Condition checks if a docker image with a specific tag is published
+func (d *Docker) Condition() (bool, error) {
 
 	if ok, err := d.Check(); !ok {
-		fmt.Println(err)
-		return ok
+		return false, err
 	}
 
 	url := fmt.Sprintf("https://%s/v2/repositories/%s/tags/%s",
@@ -58,13 +57,13 @@ func (d *Docker) IsTagPublished() bool {
 	req, err := http.NewRequest("GET", url, nil)
 
 	if err != nil {
-		fmt.Println(err)
+		return false, err
 	}
 
 	res, err := http.DefaultClient.Do(req)
 
 	if err != nil {
-		fmt.Println(err)
+		return false, err
 	}
 
 	defer res.Body.Close()
@@ -72,7 +71,7 @@ func (d *Docker) IsTagPublished() bool {
 	body, err := ioutil.ReadAll(res.Body)
 
 	if err != nil {
-		fmt.Println(err)
+		return false, err
 	}
 
 	data := map[string]string{}
@@ -81,17 +80,17 @@ func (d *Docker) IsTagPublished() bool {
 
 	if val, ok := data["message"]; ok && strings.Contains(val, "not found") {
 		fmt.Printf("\u2717 %s:%s doesn't exist on the Docker Registry \n", d.Image, d.Tag)
-		return false
+		return false, nil
 	}
 
 	if val, ok := data["name"]; ok && val == d.Tag {
 		fmt.Printf("\u2714 %s:%s available on the Docker Registry\n", d.Image, d.Tag)
-		return true
+		return true, nil
 	}
 
 	fmt.Printf("\t\t\u2717Something went wrong, no field 'name' founded from %s\n", url)
 
-	return false
+	return false, fmt.Errorf("something went wrong, no field 'name' founded from %s", url)
 }
 
 // Source retrieve docker image tag digest from a registry

--- a/pkg/docker/main.go
+++ b/pkg/docker/main.go
@@ -94,12 +94,11 @@ func (d *Docker) IsTagPublished() bool {
 	return false
 }
 
-// GetVersion retrieve docker image tag digest from a registry
-func (d *Docker) GetVersion() string {
+// Source retrieve docker image tag digest from a registry
+func (d *Docker) Source() (string, error) {
 
 	if ok, err := d.Check(); !ok {
-		fmt.Println(err)
-		return ""
+		return "", err
 	}
 
 	// https://hub.docker.com/v2/repositories/olblak/updatecli/tags/latest
@@ -111,13 +110,13 @@ func (d *Docker) GetVersion() string {
 	req, err := http.NewRequest("GET", URL, nil)
 
 	if err != nil {
-		fmt.Println(err)
+		return "", err
 	}
 
 	res, err := http.DefaultClient.Do(req)
 
 	if err != nil {
-		fmt.Println(err)
+		return "", err
 	}
 
 	defer res.Body.Close()
@@ -125,7 +124,7 @@ func (d *Docker) GetVersion() string {
 	body, err := ioutil.ReadAll(res.Body)
 
 	if err != nil {
-		fmt.Println(err)
+		return "", err
 	}
 
 	type respond struct {
@@ -143,11 +142,11 @@ func (d *Docker) GetVersion() string {
 			fmt.Printf("\u2714 Digest '%v' found for docker image %s:%s available from Docker Registry\n", digest, d.Image, d.Tag)
 			fmt.Printf("\nRemark: Do not forget to add @sha256 after your the docker image name\n")
 			fmt.Printf("Example: %v@sha256%v\n", d.Image, digest)
-			return digest
+			return digest, nil
 		}
 	}
 
 	fmt.Printf("\u2717 No Digest found for docker image %s:%s on the Docker Registry \n", d.Image, d.Tag)
 
-	return ""
+	return "", nil
 }

--- a/pkg/docker/main_test.go
+++ b/pkg/docker/main_test.go
@@ -84,7 +84,7 @@ func TestIsPublished(t *testing.T) {
 
 }
 
-func TestGetVersion(t *testing.T) {
+func TestSource(t *testing.T) {
 	// Test if existing return the correct digest
 	d := &Docker{
 		URL:   "hub.docker.com",
@@ -92,7 +92,7 @@ func TestGetVersion(t *testing.T) {
 		Image: "olblak/updatecli",
 	}
 
-	got := d.GetVersion()
+	got, _ := d.Source()
 	expected := "4f9936580d3caa6b7a27da62df78acf0294277a4b62bc128de7b88ff836ed2a9"
 
 	if got != expected {
@@ -105,7 +105,7 @@ func TestGetVersion(t *testing.T) {
 		Tag:   "donotexist",
 		Image: "olblak/updatecli",
 	}
-	got = d.GetVersion()
+	got, _ = d.Source()
 	expected = ""
 	if got != expected {
 		t.Errorf("Digest expected %v, got %v", expected, got)

--- a/pkg/docker/main_test.go
+++ b/pkg/docker/main_test.go
@@ -55,7 +55,7 @@ func TestCheck(t *testing.T) {
 	}
 }
 
-func TestIsPublished(t *testing.T) {
+func TestCondition(t *testing.T) {
 	// Test if existing image tag return true
 	d := &Docker{
 		URL:   "hub.docker.com",
@@ -63,7 +63,7 @@ func TestIsPublished(t *testing.T) {
 		Image: "olblak/updatecli",
 	}
 
-	got := d.IsTagPublished()
+	got, _ := d.Condition()
 	expected := true
 	if got != expected {
 		t.Errorf("%v:%v is published! expected %v, got %v", d.Image, d.Tag, expected, got)
@@ -76,7 +76,7 @@ func TestIsPublished(t *testing.T) {
 		Image: "olblak/updatecli",
 	}
 
-	got = d.IsTagPublished()
+	got, _ = d.Condition()
 	expected = false
 	if got != expected {
 		t.Errorf("%v:%v is not published! expected %v, got %v", d.Image, d.Tag, expected, got)

--- a/pkg/engine/condition/main.go
+++ b/pkg/engine/condition/main.go
@@ -1,9 +1,61 @@
 package condition
 
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/olblak/updateCli/pkg/docker"
+	"github.com/olblak/updateCli/pkg/maven"
+)
+
 // Condition defines which condition needs to be met
 // in order to update targets based on the source output
 type Condition struct {
 	Name string
 	Kind string
 	Spec interface{}
+}
+
+// Execute tests if a specific condition is true
+func (c *Condition) Execute(source string) (bool, error) {
+
+	ok := true
+
+	switch c.Kind {
+
+	case "dockerImage":
+		var d docker.Docker
+
+		err := mapstructure.Decode(c.Spec, &d)
+
+		if err != nil {
+			return false, err
+		}
+
+		d.Tag = source
+
+		ok = d.IsTagPublished()
+
+		fmt.Printf("\n")
+
+	case "maven":
+		var m maven.Maven
+
+		err := mapstructure.Decode(c.Spec, &m)
+
+		if err != nil {
+			panic(err)
+		}
+
+		m.Version = source
+
+		ok = m.IsTagPublished()
+		fmt.Printf("\n")
+
+	default:
+		return false, fmt.Errorf("⚠ Don't support condition: %v", c.Kind)
+	}
+
+	return ok, nil
+
 }

--- a/pkg/engine/condition/main.go
+++ b/pkg/engine/condition/main.go
@@ -16,8 +16,15 @@ type Condition struct {
 	Spec interface{}
 }
 
+// Spec is an interface to test if condition is met
+type Spec interface {
+	Condition() (bool, error)
+}
+
 // Execute tests if a specific condition is true
 func (c *Condition) Execute(source string) (bool, error) {
+
+	var spec Spec
 
 	ok := true
 
@@ -34,9 +41,7 @@ func (c *Condition) Execute(source string) (bool, error) {
 
 		d.Tag = source
 
-		ok = d.IsTagPublished()
-
-		fmt.Printf("\n")
+		spec = &d
 
 	case "maven":
 		var m maven.Maven
@@ -49,11 +54,16 @@ func (c *Condition) Execute(source string) (bool, error) {
 
 		m.Version = source
 
-		ok = m.IsTagPublished()
-		fmt.Printf("\n")
+		spec = &m
 
 	default:
 		return false, fmt.Errorf("⚠ Don't support condition: %v", c.Kind)
+	}
+
+	ok, err := spec.Condition()
+
+	if err != nil {
+		return false, err
 	}
 
 	return ok, nil

--- a/pkg/engine/condition/main.go
+++ b/pkg/engine/condition/main.go
@@ -1,0 +1,9 @@
+package condition
+
+// Condition defines which condition needs to be met
+// in order to update targets based on the source output
+type Condition struct {
+	Name string
+	Kind string
+	Spec interface{}
+}

--- a/pkg/engine/main.go
+++ b/pkg/engine/main.go
@@ -60,21 +60,21 @@ func (e *Engine) conditions(source string) (bool, error) {
 	fmt.Printf("\n\n%s:\n", strings.ToTitle("conditions"))
 	fmt.Printf("%s\n\n", strings.Repeat("=", len("conditions")+1))
 
-	ok := true
-
 	for _, c := range e.conf.Conditions {
 		ok, err := c.Execute(source)
-		if !ok {
-			fmt.Printf("\n\u26A0 skipping: condition not met")
-			ok = false
-		}
-
 		if err != nil {
 			return false, err
 		}
+
+		if !ok {
+			fmt.Printf("\n\u26A0 skipping: condition not met")
+			ok = false
+			return false, nil
+		}
+
 	}
 
-	return ok, nil
+	return true, nil
 }
 
 // targets iterate on every targets and then call target on each of them

--- a/pkg/engine/main.go
+++ b/pkg/engine/main.go
@@ -1,0 +1,94 @@
+package engine
+
+import (
+	"fmt"
+
+	"github.com/olblak/updateCli/pkg/config"
+
+	"path/filepath"
+	"strings"
+)
+
+var engine Engine
+
+// Engine defined parameters for a specific engine run
+type Engine struct {
+	conf config.Config
+}
+
+// Run run the full process one yaml file
+func Run(cfgFile string) error {
+
+	_, basename := filepath.Split(cfgFile)
+	cfgFileName := strings.TrimSuffix(basename, filepath.Ext(basename))
+
+	fmt.Printf("\n\n%s\n", strings.Repeat("#", len(cfgFileName)+4))
+	fmt.Printf("# %s #\n", strings.ToTitle(cfgFileName))
+	fmt.Printf("%s\n\n", strings.Repeat("#", len(cfgFileName)+4))
+
+	engine.conf.ReadFile(cfgFile)
+
+	engine.conf.Check()
+
+	source, err := engine.conf.Source.Execute()
+
+	if err != nil {
+		return err
+	}
+
+	if len(engine.conf.Conditions) > 0 {
+		ok, err := engine.conditions(source)
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			return nil
+		}
+	}
+
+	if len(engine.conf.Targets) > 0 {
+		engine.targets(source)
+	}
+
+	return nil
+}
+
+// conditions iterates on every conditions and test the result
+func (e *Engine) conditions(source string) (bool, error) {
+
+	fmt.Printf("\n\n%s:\n", strings.ToTitle("conditions"))
+	fmt.Printf("%s\n\n", strings.Repeat("=", len("conditions")+1))
+
+	ok := true
+
+	for _, c := range e.conf.Conditions {
+		ok, err := c.Execute(source)
+		if !ok {
+			fmt.Printf("\n\u26A0 skipping: condition not met")
+			ok = false
+		}
+
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return ok, nil
+}
+
+// targets iterate on every targets and then call target on each of them
+func (e *Engine) targets(source string) error {
+
+	fmt.Printf("\n\n%s:\n", strings.ToTitle("Targets"))
+	fmt.Printf("%s\n\n", strings.Repeat("=", len("Targets")+1))
+
+	for id, t := range e.conf.Targets {
+		err := t.Execute(source)
+		if err != nil {
+			fmt.Printf("Something went wrong in target \"%v\" :\n", id)
+			fmt.Printf("%v\n\n", err)
+		}
+	}
+	return nil
+}

--- a/pkg/engine/main.go
+++ b/pkg/engine/main.go
@@ -36,6 +36,11 @@ func Run(cfgFile string) error {
 		return err
 	}
 
+	if source == "" {
+		fmt.Printf("\n\u26A0 No value returned from Source, nothing else to do")
+		return nil
+	}
+
 	if len(engine.conf.Conditions) > 0 {
 		ok, err := engine.conditions(source)
 		if err != nil {

--- a/pkg/engine/source/main.go
+++ b/pkg/engine/source/main.go
@@ -1,5 +1,15 @@
 package source
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/olblak/updateCli/pkg/docker"
+	"github.com/olblak/updateCli/pkg/github"
+	"github.com/olblak/updateCli/pkg/maven"
+)
+
 // Source defines how a value is retrieved from a specific source
 type Source struct {
 	Kind    string
@@ -7,4 +17,49 @@ type Source struct {
 	Prefix  string
 	Postfix string
 	Spec    interface{}
+}
+
+// Execute execute actions defined by the source configuration
+func (s *Source) Execute() (string, error) {
+
+	fmt.Printf("\n\n%s:\n", strings.ToTitle("Source"))
+	fmt.Printf("%s\n\n", strings.Repeat("=", len("Source")+1))
+
+	var output string
+
+	switch s.Kind {
+	case "githubRelease":
+		var spec github.Github
+		err := mapstructure.Decode(s.Spec, &spec)
+
+		if err != nil {
+			return "", err
+		}
+		output = spec.GetVersion()
+
+	case "maven":
+		var spec maven.Maven
+		err := mapstructure.Decode(s.Spec, &spec)
+
+		if err != nil {
+			return "", err
+		}
+		output = spec.GetVersion()
+
+	case "dockerDigest":
+		var spec docker.Docker
+		err := mapstructure.Decode(s.Spec, &spec)
+
+		if err != nil {
+			return "", err
+		}
+		output = spec.GetVersion()
+
+	default:
+		return "", fmt.Errorf("⚠ Don't support source kind: %v", s.Kind)
+	}
+
+	s.Output = s.Prefix + output + s.Postfix
+
+	return s.Output, nil
 }

--- a/pkg/engine/source/main.go
+++ b/pkg/engine/source/main.go
@@ -1,0 +1,10 @@
+package source
+
+// Source defines how a value is retrieved from a specific source
+type Source struct {
+	Kind    string
+	Output  string
+	Prefix  string
+	Postfix string
+	Spec    interface{}
+}

--- a/pkg/engine/target/main.go
+++ b/pkg/engine/target/main.go
@@ -1,0 +1,9 @@
+package target
+
+// Target defines which file need to be updated based on source output
+type Target struct {
+	Name       string
+	Kind       string
+	Spec       interface{}
+	Repository interface{}
+}

--- a/pkg/engine/target/main.go
+++ b/pkg/engine/target/main.go
@@ -2,42 +2,90 @@ package target
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/olblak/updateCli/pkg/scm"
 	"github.com/olblak/updateCli/pkg/yaml"
 )
 
-// Target defines which file need to be updated based on source output
+// Target defines which file needs to be updated based on source output
 type Target struct {
-	Name       string
-	Kind       string
-	Spec       interface{}
-	Repository interface{}
+	Name string
+	Kind string
+	Spec interface{}
+	Scm  map[string]interface{}
 }
 
-// Execute apply a specific target configuration
-func (t *Target) Execute(source string) error {
+// Spec is an interface which offers common function to manipulate targets.
+type Spec interface {
+	GetFile() string
+	Target(source, workDir string) (string, error)
+}
+
+// Unmarshal parses target spec and return its Spec interface
+func (t *Target) Unmarshal() (Spec, error) {
+
+	var spec Spec
 
 	switch t.Kind {
 
 	case "yaml":
-		var spec yaml.Yaml
+		var y yaml.Yaml
 
-		err := mapstructure.Decode(t.Spec, &spec)
-
-		if err != nil {
-			return err
-		}
-
-		err = spec.Update(source)
+		err := mapstructure.Decode(t.Spec, &y)
 
 		if err != nil {
-			return err
+			return nil, err
 		}
+
+		spec = &y
 
 	default:
-		return fmt.Errorf("⚠ Don't support target: %v", t.Kind)
+		return nil, fmt.Errorf("⚠ Don't support target: %v", t.Kind)
 	}
+
+	return spec, nil
+}
+
+// Execute applies a specific target configuration
+func (t *Target) Execute(source string) error {
+
+	scm, err := scm.Unmarshal(t.Scm)
+	if err != nil {
+		return err
+	}
+
+	spec, err := t.Unmarshal()
+
+	if err != nil {
+		return err
+	}
+
+	err = scm.Init(source)
+	if err != nil {
+		return err
+	}
+
+	file := spec.GetFile()
+
+	path := filepath.Join(scm.GetDirectory(), file)
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		scm.Clone()
+	}
+
+	message, err := spec.Target(source, scm.GetDirectory())
+
+	if err != nil {
+		return err
+	}
+
+	scm.Add(file)
+	scm.Commit(file, message)
+	scm.Push()
+	scm.Clean()
 
 	return nil
 }

--- a/pkg/engine/target/main.go
+++ b/pkg/engine/target/main.go
@@ -1,9 +1,43 @@
 package target
 
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/olblak/updateCli/pkg/yaml"
+)
+
 // Target defines which file need to be updated based on source output
 type Target struct {
 	Name       string
 	Kind       string
 	Spec       interface{}
 	Repository interface{}
+}
+
+// Execute apply a specific target configuration
+func (t *Target) Execute(source string) error {
+
+	switch t.Kind {
+
+	case "yaml":
+		var spec yaml.Yaml
+
+		err := mapstructure.Decode(t.Spec, &spec)
+
+		if err != nil {
+			return err
+		}
+
+		err = spec.Update(source)
+
+		if err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf("⚠ Don't support target: %v", t.Kind)
+	}
+
+	return nil
 }

--- a/pkg/git/main.go
+++ b/pkg/git/main.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 )
 
-// Git contains settings to interact with a specific git repository.
+// Git contains settings to manipulate a git repository.
 type Git struct {
 	URL       string
 	Branch    string
@@ -20,15 +20,16 @@ type Git struct {
 	Version   string
 }
 
-// GetDirectory returns the git working directory
+// GetDirectory returns the working git directory.
 func (g *Git) GetDirectory() (directory string) {
 	return g.Directory
 }
 
-// Init Git struct
-func (g *Git) Init(version string) {
-	g.Version = version
-	g.setDirectory(version)
+// Init set Git parameters if needed.
+func (g *Git) Init(source string) error {
+	g.Version = source
+	g.setDirectory(source)
+	return nil
 }
 
 func (g *Git) setDirectory(version string) {
@@ -48,12 +49,12 @@ func (g *Git) setDirectory(version string) {
 	fmt.Printf("Directory: %v\n", g.Directory)
 }
 
-// Clean remove unneeded git repository from local storage
+// Clean removes the current git repository from local storage.
 func (g *Git) Clean() {
 	os.RemoveAll(g.Directory) // clean up
 }
 
-// Clone run `git clone`
+// Clone run `git clone`.
 func (g *Git) Clone() string {
 
 	_, err := git.PlainClone(g.Directory, false, &git.CloneOptions{
@@ -70,7 +71,7 @@ func (g *Git) Clone() string {
 	return g.Directory
 }
 
-// Commit run `git commit`
+// Commit run `git commit`.
 func (g *Git) Commit(file, message string) {
 	// Opens an already existing repository.
 	r, err := git.PlainOpen(g.Directory)
@@ -107,7 +108,7 @@ func (g *Git) Commit(file, message string) {
 
 }
 
-// Add run `git add`
+// Add run `git add`.
 func (g *Git) Add(file string) {
 
 	fmt.Printf("Adding file: %s\n", file)
@@ -127,7 +128,7 @@ func (g *Git) Add(file string) {
 	}
 }
 
-// TmpBranch creates a ephemeral branch
+// TmpBranch creates an ephemeral branch.
 func (g *Git) TmpBranch(name string) {
 
 	r, err := git.PlainOpen(g.Directory)
@@ -150,7 +151,7 @@ func (g *Git) TmpBranch(name string) {
 	}
 }
 
-// Push run `git push`
+// Push run `git push`.
 func (g *Git) Push() {
 
 	r, err := git.PlainOpen(g.Directory)

--- a/pkg/github/main.go
+++ b/pkg/github/main.go
@@ -31,12 +31,12 @@ type Github struct {
 	Email        string
 }
 
-// GetDirectory returns the local git repository path
+// GetDirectory returns the local git repository path.
 func (g *Github) GetDirectory() (directory string) {
 	return g.directory
 }
 
-// Source retrieves the version tag from Github Releases
+// Source retrieves a specific version tag from Github Releases.
 func (g *Github) Source() (string, error) {
 
 	_, err := g.Check()
@@ -83,7 +83,7 @@ func (g *Github) Source() (string, error) {
 
 }
 
-// Check verify that mandatory Github parameters are provided
+// Check verifies if mandatory Github parameters are provided and return false if not.
 func (g *Github) Check() (bool, error) {
 	ok := true
 	required := []string{}
@@ -113,16 +113,16 @@ func (g *Github) Check() (bool, error) {
 
 }
 
-// Init Github struct
-func (g *Github) Init(version string) {
-	g.Version = version
-	g.setDirectory(version)
-	g.remoteBranch = fmt.Sprintf("updatecli/%v", version)
+// Init set default Github parameters if not set.
+func (g *Github) Init(source string) error {
+	g.Version = source
+	g.setDirectory(source)
+	g.remoteBranch = fmt.Sprintf("updatecli/%v", source)
 
 	if ok, err := g.Check(); !ok {
-		fmt.Println(err)
+		return err
 	}
-
+	return nil
 }
 
 func (g *Github) setDirectory(version string) {
@@ -140,12 +140,12 @@ func (g *Github) setDirectory(version string) {
 	g.directory = directory
 }
 
-// Clean Github working directory
+// Clean deletes github working directory.
 func (g *Github) Clean() {
 	os.RemoveAll(g.directory)
 }
 
-// Clone run `git clone`
+// Clone run `git clone`.
 func (g *Github) Clone() string {
 	fmt.Printf("Cloning git repository: \n\n")
 	URL := fmt.Sprintf("https://%v:%v@github.com/%v/%v.git",
@@ -169,7 +169,7 @@ func (g *Github) Clone() string {
 	return g.directory
 }
 
-// Commit run `git commit`
+// Commit run `git commit`.
 func (g *Github) Commit(file, message string) {
 	r, err := git.PlainOpen(g.directory)
 	if err != nil {
@@ -205,7 +205,7 @@ func (g *Github) Commit(file, message string) {
 
 }
 
-// Checkout create and use a temporary branch
+// Checkout create and then uses a temporary git branch.
 func (g *Github) Checkout() {
 	r, err := git.PlainOpen(g.directory)
 	if err != nil {
@@ -233,7 +233,7 @@ func (g *Github) Checkout() {
 	fmt.Printf("\n")
 }
 
-// Add run `git add`
+// Add run `git add`.
 func (g *Github) Add(file string) {
 
 	fmt.Printf("Adding file: %s\n", file)
@@ -254,7 +254,7 @@ func (g *Github) Add(file string) {
 	}
 }
 
-// Push run `git push`
+// Push run `git push` then open a pull request on Github if not already created.
 func (g *Github) Push() {
 
 	r, err := git.PlainOpen(g.directory)
@@ -286,7 +286,7 @@ func (g *Github) Push() {
 	g.OpenPR()
 }
 
-// OpenPR creates a new pull request
+// OpenPR creates a new pull request.
 func (g *Github) OpenPR() {
 	title := fmt.Sprintf("[Updatecli] Update version to %v", g.Version)
 
@@ -342,7 +342,7 @@ func (g *Github) OpenPR() {
 
 }
 
-// isPRExist checks if an open pull request already exist based on a title
+// isPRExist checks if an open pull request already exist based on a title.
 func (g *Github) isPRExist(title string) bool {
 
 	URL := fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls",

--- a/pkg/maven/main.go
+++ b/pkg/maven/main.go
@@ -83,8 +83,8 @@ func (m *Maven) IsTagPublished() bool {
 	return false
 }
 
-// GetVersion return the latest version
-func (m *Maven) GetVersion() string {
+// Source return the latest version
+func (m *Maven) Source() (string, error) {
 	URL := fmt.Sprintf("https://%s/%s/%s/%s/maven-metadata.xml",
 		m.URL,
 		m.Repository,
@@ -94,13 +94,13 @@ func (m *Maven) GetVersion() string {
 	req, err := http.NewRequest("GET", URL, nil)
 
 	if err != nil {
-		fmt.Println(err)
+		return "", err
 	}
 
 	res, err := http.DefaultClient.Do(req)
 
 	if err != nil {
-		fmt.Println(err)
+		return "", err
 	}
 
 	defer res.Body.Close()
@@ -108,7 +108,7 @@ func (m *Maven) GetVersion() string {
 	body, err := ioutil.ReadAll(res.Body)
 
 	if err != nil {
-		fmt.Println(err)
+		return "", err
 	}
 
 	data := Metadata{}
@@ -117,9 +117,9 @@ func (m *Maven) GetVersion() string {
 
 	if data.Versioning.Latest != "" {
 		fmt.Printf("\u2714 Latest version is %s on Maven Repository\n", data.Versioning.Latest)
-		return data.Versioning.Latest
+		return data.Versioning.Latest, nil
 	}
 
 	fmt.Printf("\u2717 No latest version on Maven Repository\n")
-	return ""
+	return "", nil
 }

--- a/pkg/maven/main.go
+++ b/pkg/maven/main.go
@@ -39,8 +39,8 @@ type Versions struct {
 	Version []string `xml:"version"`
 }
 
-// IsTagPublished test if a specific version exist on the maven repository
-func (m *Maven) IsTagPublished() bool {
+// Condition tests if a specific version exist on the maven repository
+func (m *Maven) Condition() (bool, error) {
 	URL := fmt.Sprintf("https://%s/%s/%s/%s/maven-metadata.xml",
 		m.URL,
 		m.Repository,
@@ -50,13 +50,13 @@ func (m *Maven) IsTagPublished() bool {
 	req, err := http.NewRequest("GET", URL, nil)
 
 	if err != nil {
-		fmt.Println(err)
+		return false, err
 	}
 
 	res, err := http.DefaultClient.Do(req)
 
 	if err != nil {
-		fmt.Println(err)
+		return false, err
 	}
 
 	defer res.Body.Close()
@@ -64,7 +64,7 @@ func (m *Maven) IsTagPublished() bool {
 	body, err := ioutil.ReadAll(res.Body)
 
 	if err != nil {
-		fmt.Println(err)
+		return false, err
 	}
 
 	data := Metadata{}
@@ -74,13 +74,13 @@ func (m *Maven) IsTagPublished() bool {
 	for _, version := range data.Versioning.Versions.Version {
 		if version == m.Version {
 			fmt.Printf("\u2714 Version %s is available on Maven Repository\n", m.Version)
-			return true
+			return true, nil
 		}
 
 	}
 
 	fmt.Printf("\u2717 Version %s is not available on Maven Repository\n", m.Version)
-	return false
+	return false, nil
 }
 
 // Source return the latest version

--- a/pkg/maven/main_test.go
+++ b/pkg/maven/main_test.go
@@ -2,7 +2,7 @@ package maven
 
 import "testing"
 
-func TestIsPublished(t *testing.T) {
+func TestCondition(t *testing.T) {
 	// Test if existing image tag return true
 	m := &Maven{
 		URL:        "repo.jenkins-ci.org",
@@ -12,7 +12,7 @@ func TestIsPublished(t *testing.T) {
 		Version:    "1.7.4.v20130429",
 	}
 
-	got := m.IsTagPublished()
+	got, _ := m.Condition()
 	expected := true
 	if got != expected {
 		t.Errorf("ArtifactID %v is published! expected %v, got %v", m.ArtifactID, expected, got)
@@ -27,7 +27,7 @@ func TestIsPublished(t *testing.T) {
 		Version:    "0.3",
 	}
 
-	got = m.IsTagPublished()
+	got, _ = m.Condition()
 	expected = false
 	if got != expected {
 		t.Errorf("ArtifactID %v is not published! expected %v, got %v", m.ArtifactID, expected, got)

--- a/pkg/maven/main_test.go
+++ b/pkg/maven/main_test.go
@@ -34,7 +34,7 @@ func TestIsPublished(t *testing.T) {
 	}
 }
 
-func TestGetVersion(t *testing.T) {
+func TestSource(t *testing.T) {
 	// Test if existing image tag return true
 	m := &Maven{
 		URL:        "repo.jenkins-ci.org",
@@ -43,7 +43,7 @@ func TestGetVersion(t *testing.T) {
 		ArtifactID: "wikitext.core",
 	}
 
-	got := m.GetVersion()
+	got, _ := m.Source()
 	expected := "1.7.4.v20130429"
 	if got != expected {
 		t.Errorf("Latest version published expected is %v, got %v", expected, got)
@@ -58,7 +58,7 @@ func TestGetVersion(t *testing.T) {
 		Version:    "0.3",
 	}
 
-	got = m.GetVersion()
+	got, _ = m.Source()
 	expected = "2.21"
 	if got == expected {
 		t.Errorf("Latest version published expected is %v, got %v", expected, got)

--- a/pkg/scm/main.go
+++ b/pkg/scm/main.go
@@ -1,12 +1,60 @@
 package scm
 
-// Scm is an interface in from of source controle manager like git or github
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/olblak/updateCli/pkg/git"
+	"github.com/olblak/updateCli/pkg/github"
+)
+
+// Scm is an interface that offers common functions for a source control manager like git or github
 type Scm interface {
 	Add(file string)
 	Clone() string
 	GetDirectory() (directory string)
-	Init(version string)
+	Init(source string) error
 	Push()
 	Commit(file, message string)
 	Clean()
+}
+
+// Unmarshal parses a scm struct like git or github and returns a scm interface
+func Unmarshal(scm map[string]interface{}) (Scm, error) {
+	var s Scm
+	if len(scm) != 1 {
+		return nil, fmt.Errorf("Target scm: Only one scm can be provided [git,github]")
+	}
+
+	for key, value := range scm {
+		switch key {
+		case "github":
+
+			var g github.Github
+
+			err := mapstructure.Decode(value, &g)
+
+			if err != nil {
+				return nil, err
+			}
+
+			s = &g
+
+		case "git":
+			g := git.Git{}
+
+			err := mapstructure.Decode(value, &g)
+
+			if err != nil {
+				return nil, err
+			}
+
+			s = &g
+
+		default:
+			return nil, fmt.Errorf("wrong scm type provided, accepted values [git,github]")
+
+		}
+	}
+	return s, nil
 }

--- a/pkg/yaml/main.go
+++ b/pkg/yaml/main.go
@@ -70,7 +70,7 @@ func searchAndUpdateVersion(entry *yaml.Node, keys []string, version string, col
 }
 
 // Update updates a scm repository based on yaml modification
-func (y *Yaml) Update(version string) {
+func (y *Yaml) Update(version string) error {
 	var scm scm.Scm
 
 	switch y.Scm {
@@ -99,7 +99,7 @@ func (y *Yaml) Update(version string) {
 
 		scm = &g
 	default:
-		fmt.Printf("Something went wrong while looking at yaml repository of kind\n")
+		return fmt.Errorf("wrong scm type provided, accepted values [git,github]")
 	}
 
 	fmt.Printf("\nUpdating key  '%s' from target file: %s:\n\n", y.Key, y.File)
@@ -137,14 +137,14 @@ func (y *Yaml) Update(version string) {
 	if valueFound {
 		if oldVersion == version {
 			fmt.Printf("\u2714 Value '%s' already up to date\n", version)
-			return
+			return nil
 		}
 
 		fmt.Printf("\u2717 Version mismatched between %s (old) and %s (new)\n", oldVersion, version)
 
 	} else {
 		fmt.Printf("\u2717 cannot find key '%v' in file %v\n", y.Key, path)
-		return
+		return nil
 	}
 
 	message := fmt.Sprintf("Updating key '%v' to %s",
@@ -169,4 +169,5 @@ func (y *Yaml) Update(version string) {
 	scm.Commit(y.File, message)
 	scm.Push()
 	scm.Clean()
+	return nil
 }

--- a/pkg/yaml/main.go
+++ b/pkg/yaml/main.go
@@ -108,7 +108,7 @@ func (y *Yaml) Target(source string, workDir string) (message string, err error)
 		return "", nil
 	}
 
-	message = fmt.Sprintf("[%s] Updating key from '%v' to %s",
+	message = fmt.Sprintf("[updatecli] %s - Updating key '%v' to %s",
 		y.File,
 		y.Key,
 		source)

--- a/pkg/yaml/main.go
+++ b/pkg/yaml/main.go
@@ -3,7 +3,6 @@ package yaml
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -80,7 +79,7 @@ func (y *Yaml) Update(version string) error {
 		err := mapstructure.Decode(y.Repository, &g)
 
 		if err != nil {
-			fmt.Println(err)
+			return err
 		}
 
 		g.GetDirectory()
@@ -92,7 +91,7 @@ func (y *Yaml) Update(version string) error {
 		err := mapstructure.Decode(y.Repository, &g)
 
 		if err != nil {
-			fmt.Println(err)
+			return err
 		}
 
 		g.GetDirectory()
@@ -114,14 +113,14 @@ func (y *Yaml) Update(version string) error {
 
 	file, err := os.Open(path)
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
 
 	defer file.Close()
 
 	data, err := ioutil.ReadAll(file)
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
 
 	var out yaml.Node
@@ -129,7 +128,7 @@ func (y *Yaml) Update(version string) error {
 	err = yaml.Unmarshal(data, &out)
 
 	if err != nil {
-		log.Printf("cannot unmarshal data: %v", err)
+		return fmt.Errorf("cannot unmarshal data: %v", err)
 	}
 
 	valueFound, oldVersion, _ := searchAndUpdateVersion(&out, strings.Split(y.Key, "."), version, 1)
@@ -162,7 +161,7 @@ func (y *Yaml) Update(version string) error {
 	err = encoder.Encode(&out)
 
 	if err != nil {
-		log.Fatalf("Something went wrong while encoding %v\n", err)
+		return fmt.Errorf("something went wrong while encoding %v", err)
 	}
 
 	scm.Add(y.File)

--- a/updateCli.d/jenkins-wiki-exporter.yaml
+++ b/updateCli.d/jenkins-wiki-exporter.yaml
@@ -21,9 +21,8 @@ targets:
     spec:
       file: "charts/jenkins-wiki-exporter/values.yaml"
       key: image.tag
-      message: "[updatecli][jenkins-wiki-exporter] Default image tag updated"
-      scm: "github"
-      repository:
+    scm:
+      github:
         user: "update-bot"
         email: "update-bot@olblak.com"
         owner: "olblak"
@@ -31,15 +30,29 @@ targets:
         token: ""
         username: "olblak"
         branch: "master"
+  #appVersion:
+  #  name: "Chart appVersion"
+  #  kind: yaml
+  #  spec:
+  #    file: "charts/jenkins-wiki-exporter/Chart.yaml"
+  #    key: appVersion
+  #  scm:
+  #    github:
+  #      user: "updatecli"
+  #      email: "updatecli@olblak.com"
+  #      owner: "olblak"
+  #      repository: "charts"
+  #      token: ""
+  #      username: "olblak"
+  #      branch: "master"
   appVersion:
     name: "Chart appVersion"
     kind: yaml
     spec:
       file: "charts/jenkins-wiki-exporter/Chart.yaml"
       key: appVersion
-      message: "[updatecli][jenkins-wiki-exporter] Helm chart appVersion updated"
-      scm: "github"
-      repository:
+    scm:
+      github:
         user: "updatecli"
         email: "updatecli@olblak.com"
         owner: "olblak"

--- a/updateCli.d/jenkins.yaml
+++ b/updateCli.d/jenkins.yaml
@@ -21,9 +21,8 @@ targets:
     spec:
       file: "charts/jenkins/values.yaml"
       key: "jenkins.master.imageTag"
-      message: "[updatecli][Jenkins] Update default jenkins docker image tag"
-      scm: "github"
-      repository:
+    scm:
+      github:
         user: "updatecli"
         email: "updatecli@olblak.com"
         owner: "olblak"

--- a/updateCli.d/nginx.yaml
+++ b/updateCli.d/nginx.yaml
@@ -1,0 +1,22 @@
+source:
+  kind: dockerDigest
+  spec:
+    image: "library/nginx"
+    tag: "1.17"
+targets:
+  jenkinsioNginxDigest:
+    name: "Jenkins.io nginx"
+    kind: yaml
+    spec:
+      file: "charts/jenkins.io/values.yaml"
+      key: image.tag
+      message: "[updatecli][jenkins.io] Nginx image digest updated"
+    scm:
+      github:
+        user: "update-bot"
+        email: "update-bot@olblak.com"
+        owner: "jenkins-infra"
+        repository: "charts"
+        token: ""
+        username: "olblak"
+        branch: "master"

--- a/updateCli.d/pluginsite-api.yaml
+++ b/updateCli.d/pluginsite-api.yaml
@@ -21,9 +21,8 @@ targets:
     spec:
       file: "charts/plugin-site/values.yaml"
       key: "backend.image.tag"
-      message: "[updatecli][pluginsite] Default image tag updated"
-      scm: "github"
-      repository:
+    scm:
+      github:
         user: "updatecli"
         email: "updatecli@olblak.com"
         owner: "olblak"
@@ -37,9 +36,8 @@ targets:
     spec:
       file: "charts/plugin-site/Chart.yaml"
       key: appVersion
-      message: "[updatecli][pluginsite-api] Helm Chart appVersion updated"
-      scm: "github"
-      repository:
+    scm: 
+      github:
         user: "updatecli"
         email: "updatecli@olblak.com"
         owner: "olblak"
@@ -47,8 +45,7 @@ targets:
         token: ""
         username: "olblak"
         branch: "master"
-  #    scm: "git"
-  #    repository:
+  #    git:
   #      url: "git@github.com:olblak/charts.git"
   #      branch: "master"
   #      user: "update-bot"


### PR DESCRIPTION
* Improve error handling.
* Move source, condition, target to separated packages
* Refactor target schema, SCM is not anymore under YAML spec

```
   appVersion:
     name: "Chart appVersion"
     kind: yaml
     spec:
       file: "charts/jenkins-wiki-exporter/Chart.yaml"
       key: appVersion
-      message: "[updatecli][jenkins-wiki-exporter] Helm chart appVersion updated"
-      scm: "github"
-      repository:
+    scm:
+      github:
         user: "updatecli"
         email: "updatecli@olblak.com"

```

Closes: #11