### PR TITLE
Add configuration option using go templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,11 @@ github:
 
 ## Usage
 
-A configuration can be specified by using --config, it accepts either a single file or a directory, if a directory is specified, then it checks for every files inside.
+A YAML configuration can be specified using `--config <yaml_file>`, it accepts either a single file or a directory, if a directory is specified, then it runs on every file inside.
+
+Another way to use this tool is by using go template files in place of YAML, in that case, updateCli accepts the parameter --values <yaml file> to specify YAML key value and then they can then referenced from the go template using {{ key.key2 }}.
+We also provide a custom function called requireEnd to inject any environment variable in the template example, `{{ requiredEnv "PATH" }}`.
+
 
 ## Examples
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,8 @@ import (
 )
 
 var (
-	cfgFile string
+	cfgFile    string
+	valuesFile string
 
 	rootCmd = &cobra.Command{
 		Use:   "updateCli",
@@ -36,6 +37,7 @@ func Execute() {
 
 func init() {
 	rootCmd.Flags().StringVarP(&cfgFile, "config", "c", "./updateCli.yaml", "config file (default is ./updateCli.yaml)")
+	rootCmd.Flags().StringVarP(&valuesFile, "values", "v", "./values.yaml", "values file (default is ./values.yaml)")
 }
 
 func run(cfg string) {

--- a/pkg/config/main.go
+++ b/pkg/config/main.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -69,8 +68,6 @@ func (config *Config) ReadFile(cfgFile string) {
 	default:
 		fmt.Printf("File extension not supported: %v", extension)
 	}
-
-	os.Exit(32)
 
 }
 

--- a/pkg/config/main.go
+++ b/pkg/config/main.go
@@ -2,14 +2,14 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/spf13/viper"
 
 	"github.com/olblak/updateCli/pkg/engine/condition"
 	"github.com/olblak/updateCli/pkg/engine/source"
 	"github.com/olblak/updateCli/pkg/engine/target"
+	"github.com/spf13/viper"
 )
 
 // Config contains cli configuration
@@ -30,29 +30,48 @@ func (config *Config) Reset() {
 func (config *Config) ReadFile(cfgFile string) {
 
 	config.Reset()
-	v := viper.New()
 
 	dirname, basename := filepath.Split(cfgFile)
 
-	v.SetEnvPrefix("updatecli")
-	v.AutomaticEnv()
-	v.SetConfigName(strings.TrimSuffix(basename, filepath.Ext(basename))) // name of config file (without extension)
-	v.SetConfigType(strings.Replace(filepath.Ext(basename), ".", "", -1)) // REQUIRED if the config file does not have the extension in the name
-	v.AddConfigPath(dirname)                                              // optionally look for config in the working directory
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	switch extension := filepath.Ext(basename); extension {
+	case ".tpl", ".tmpl":
+		t := Template{
+			CfgFile:    filepath.Join(dirname, basename),
+			ValuesFile: "values.yaml",
+		}
 
-	if err := v.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			fmt.Println("Config file not found")
-		} else {
+		err := t.Unmarshal(config)
+		if err != nil {
 			fmt.Println(err)
 		}
+
+	case ".yaml", ".yml":
+		v := viper.New()
+
+		v.SetEnvPrefix("updatecli")
+		v.AutomaticEnv()
+		v.SetConfigName(strings.TrimSuffix(basename, filepath.Ext(basename))) // name of config file (without extension)
+		v.SetConfigType(strings.Replace(filepath.Ext(basename), ".", "", -1)) // REQUIRED if the config file does not have the extension in the name
+		v.AddConfigPath(dirname)                                              // optionally look for config in the working directory
+		v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+
+		if err := v.ReadInConfig(); err != nil {
+			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+				fmt.Println("Config file not found")
+			} else {
+				fmt.Println(err)
+			}
+		}
+		err := v.Unmarshal(&config)
+		if err != nil {
+			fmt.Printf("unable to decode into struct, %v\n", err)
+		}
+	default:
+		fmt.Printf("File extension not supported: %v", extension)
 	}
 
-	err := v.Unmarshal(&config)
-	if err != nil {
-		fmt.Printf("unable to decode into struct, %v\n", err)
-	}
+	os.Exit(32)
+
 }
 
 // Check is a function that test if the configuration is correct

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"os"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Template contains template information
+type Template struct {
+	Values     map[string]interface{} `yaml:"-,inline"`
+	ValuesFile string
+	CfgFile    string
+}
+
+// Unmarshal parse golang templates then return its config struct
+func (t *Template) Unmarshal(config *Config) error {
+
+	funcMap := template.FuncMap{
+		// Retrieve value from environment variable, return error if not found
+		"requiredEnv": func(env string) (string, error) {
+			value := os.Getenv(env)
+			if value == "" {
+				return "", errors.New("No value found for environment variable " + env)
+			}
+			return value, nil
+		},
+	}
+
+	c, err := os.Open(t.CfgFile)
+
+	defer c.Close()
+	if err != nil {
+		return err
+	}
+
+	v, err := os.Open(t.ValuesFile)
+	defer v.Close()
+	if err != nil {
+		return err
+	}
+
+	content, err := ioutil.ReadAll(v)
+	if err != nil {
+		return err
+	}
+
+	yaml.Unmarshal(content, &t.Values)
+
+	content, err = ioutil.ReadAll(c)
+	if err != nil {
+		return err
+	}
+
+	tmpl := template.Must(template.New("cfg").Funcs(funcMap).Parse(string(content)))
+
+	if err != nil {
+		return err
+	}
+
+	b := bytes.Buffer{}
+
+	if err := tmpl.Execute(&b, t.Values); err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(b.Bytes(), &config)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/updateCli.d/jenkinsio.tpl
+++ b/updateCli.d/jenkinsio.tpl
@@ -1,0 +1,21 @@
+source:
+  kind: dockerDigest
+  spec:
+    image: "library/nginx"
+    tag: "1.17"
+targets:
+  jenkinsio:
+    name: "Jenkins.io nginx"
+    kind: yaml
+    spec:
+      file: "charts/jenkinsio/values.yaml"
+      key: image.tag
+    scm:
+      github:
+        user: "update-bot"
+        email: "update-bot@olblak.com"
+        owner: "jenkins-infra"
+        repository: "charts"
+        token: "{{ requiredEnv "GITHUB_TOKEN" }}"
+        username: "olblak"
+        branch: "master"


### PR DESCRIPTION
If a configuration file has an extension .tmpl or tpl, then it uses the go template engine to generate the finale configuration file, which allow more flexibility 

https://github.com/olblak/updatecli/issues/32 

Example
`./bin/updatecli --config updateCli.test.tpl --values values.yaml`