### PR TITLE
make title and message pretty

### DIFF
--- a/pkg/git/main.go
+++ b/pkg/git/main.go
@@ -12,12 +12,13 @@ import (
 
 // Git contains settings to manipulate a git repository.
 type Git struct {
-	URL       string
-	Branch    string
-	User      string
-	Email     string
-	Directory string
-	Version   string
+	URL          string
+	Branch       string
+	remoteBranch string
+	User         string
+	Email        string
+	Directory    string
+	Version      string
 }
 
 // GetDirectory returns the working git directory.
@@ -26,9 +27,10 @@ func (g *Git) GetDirectory() (directory string) {
 }
 
 // Init set Git parameters if needed.
-func (g *Git) Init(source string) error {
+func (g *Git) Init(source string, name string) error {
 	g.Version = source
 	g.setDirectory(source)
+	g.remoteBranch = fmt.Sprintf("updatecli/%v/%v", name, source)
 	return nil
 }
 
@@ -160,7 +162,7 @@ func (g *Git) Push() {
 	}
 
 	err = r.Push(&git.PushOptions{
-		RemoteName: g.Branch,
+		RemoteName: g.remoteBranch,
 	})
 	if err != nil {
 		fmt.Println(err)

--- a/pkg/github/main.go
+++ b/pkg/github/main.go
@@ -25,6 +25,7 @@ type Github struct {
 	Token        string
 	URL          string
 	Version      string
+	Name         string
 	directory    string
 	Branch       string
 	remoteBranch string
@@ -115,10 +116,11 @@ func (g *Github) Check() (bool, error) {
 }
 
 // Init set default Github parameters if not set.
-func (g *Github) Init(source string) error {
+func (g *Github) Init(source string, name string) error {
 	g.Version = source
+	g.Name = name
 	g.setDirectory(source)
-	g.remoteBranch = fmt.Sprintf("updatecli/%v", source)
+	g.remoteBranch = fmt.Sprintf("updatecli/%v/%v", g.Name, g.Version)
 
 	if ok, err := g.Check(); !ok {
 		return err
@@ -226,7 +228,7 @@ func (g *Github) Checkout() {
 		fmt.Println(err)
 	}
 
-	branch := "updatecli/" + g.Version
+	branch := fmt.Sprintf("updatecli/%v/%v", g.Name, g.Version)
 	fmt.Printf("Checkout Git Branch: %v\n", branch)
 
 	err = w.Checkout(&git.CheckoutOptions{
@@ -300,7 +302,7 @@ func (g *Github) Push() {
 // OpenPR creates a new pull request.
 func (g *Github) OpenPR() {
 	fmt.Println("Opening Github pull request")
-	title := fmt.Sprintf("[Updatecli] Update version to %v", g.Version)
+	title := fmt.Sprintf("[updatecli] Update %v version to %v", g.Name, g.Version)
 
 	if g.isPRExist(title) {
 		fmt.Printf("Pull Request titled '%v' already exist\n", title)

--- a/pkg/scm/main.go
+++ b/pkg/scm/main.go
@@ -13,7 +13,7 @@ type Scm interface {
 	Add(file string)
 	Clone() string
 	GetDirectory() (directory string)
-	Init(source string) error
+	Init(source string, name string) error
 	Push()
 	Commit(file, message string)
 	Clean()

--- a/pkg/yaml/main.go
+++ b/pkg/yaml/main.go
@@ -67,7 +67,7 @@ func replace(entry *yaml.Node, keys []string, version string, columnRef int) (fo
 }
 
 // Target updates a scm repository based on the modified yaml file.
-func (y *Yaml) Target(source string, workDir string) (changed bool, message string, err error) {
+func (y *Yaml) Target(source string, name string, workDir string) (changed bool, message string, err error) {
 
 	changed = false
 
@@ -115,7 +115,9 @@ func (y *Yaml) Target(source string, workDir string) (changed bool, message stri
 		return changed, "", nil
 	}
 
-	message = fmt.Sprintf("[updatecli] Key '%s', from file '%v', was updated to '%s'\n",
+	message = fmt.Sprintf("[updatecli] Update %s version to %v\n\nKey '%s', from file '%v', was updated to '%s'\n",
+		name,
+		source,
 		y.Key,
 		y.File,
 		source)


### PR DESCRIPTION
This works out great.
Here you got the updated commit message:
```
[updatecli] Update external-dns version to 2.20.4

Key 'versions.externalDns', from file 'system-services/helm/values.yaml', was updated to '2.20.4'
```

Not sure making name required is desired or not but for my use-case it works.

I was thinking of taking the name from source if none is supplied but it became cumbersome changeset.
for maven you would use `artifactId` and github release you would use `repository`
for docker you would use `imageName` and helm chart you would use chart `name`

WDYT?

![image](https://user-images.githubusercontent.com/1661688/86060941-15006780-ba66-11ea-89b8-fce185e14621.png)
