### PR TITLE
Only use prefix/postfix when updating target

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ source:
 	artifactID: "jenkins-war",
 ```
 
+### Prefix/Postfix
+A prefix and/or postfix can be added to any value retrieved from the source.
+This prefix/postfix will be used by 'condition' checks, then by every target unless one is explicitly defined in a target.
+
+.Example
+```
+source:
+  kind: githubRelease
+  prefix: "v"
+  postfix: "-beta"
+  spec:
+    owner: "Github Owner"
+    repository: "Github Repository"
+    token: "Don't commit your secrets!"
+    url: "Github Url"
+    version: "Version to fetch"
+```
+
+
 ## Condition
 During this stage, we check if conditions are met based on the value retrieved in the source stage otherwise we can skip the "target" stage.
 
@@ -170,6 +189,32 @@ github:
   token: "github token with enough permission on repository"
   username: "github username used for push git changes"
   branch: "git branch where to push changes"
+```
+
+### Prefix/Postfix
+A prefix and/or postfix can be added based value retrieved from the source.
+This prefix/postfix won't be used by 'condition' checks. Any value specified at the target level override values defined in the source.
+
+.Example
+```
+targets:
+  imageTag:
+    name: "Docker Image"
+    kind: yaml
+    prefix: "beta-"
+    postfix: "-jdk11"
+    spec:
+      file: "charts/jenkins/values.yaml"
+      key: "jenkins.master.imageTag"
+    scm:
+      github:
+        user: "updatecli"
+        email: "updatecli@example.com"
+        owner: "jenkins-infra"
+        repository: "charts"
+        token: {{ requiredEnv "GITHUB_TOKEN" }}
+        username: "updatecli"
+        branch: "master"
 ```
 
 ## Usage

--- a/pkg/engine/main.go
+++ b/pkg/engine/main.go
@@ -65,7 +65,8 @@ func (e *Engine) conditions() (bool, error) {
 	fmt.Printf("%s\n\n", strings.Repeat("=", len("conditions")+1))
 
 	for _, c := range e.conf.Conditions {
-		ok, err := c.Execute(e.conf.Source.Output)
+		ok, err := c.Execute(
+			e.conf.Source.Prefix + e.conf.Source.Output + e.conf.Source.Postfix)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/engine/main.go
+++ b/pkg/engine/main.go
@@ -29,19 +29,19 @@ func (e *Engine) Apply(cfgFile string) error {
 
 	e.conf.ReadFile(cfgFile, e.Options.ValuesFile)
 
-	source, err := e.conf.Source.Execute()
+	err := e.conf.Source.Execute()
 
 	if err != nil {
 		return err
 	}
 
-	if source == "" {
+	if e.conf.Source.Output == "" {
 		fmt.Printf("\n\u26A0 No value returned from Source, nothing else to do")
 		return nil
 	}
 
 	if len(e.conf.Conditions) > 0 {
-		ok, err := e.conditions(source)
+		ok, err := e.conditions()
 		if err != nil {
 			return err
 		}
@@ -52,20 +52,20 @@ func (e *Engine) Apply(cfgFile string) error {
 	}
 
 	if len(e.conf.Targets) > 0 {
-		e.targets(source)
+		e.targets()
 	}
 
 	return nil
 }
 
 // conditions iterates on every conditions and test the result
-func (e *Engine) conditions(source string) (bool, error) {
+func (e *Engine) conditions() (bool, error) {
 
 	fmt.Printf("\n\n%s:\n", strings.ToTitle("conditions"))
 	fmt.Printf("%s\n\n", strings.Repeat("=", len("conditions")+1))
 
 	for _, c := range e.conf.Conditions {
-		ok, err := c.Execute(source)
+		ok, err := c.Execute(e.conf.Source.Output)
 		if err != nil {
 			return false, err
 		}
@@ -82,13 +82,22 @@ func (e *Engine) conditions(source string) (bool, error) {
 }
 
 // targets iterate on every targets and then call target on each of them
-func (e *Engine) targets(source string) error {
+func (e *Engine) targets() error {
 
 	fmt.Printf("\n\n%s:\n", strings.ToTitle("Targets"))
 	fmt.Printf("%s\n\n", strings.Repeat("=", len("Targets")+1))
 
 	for id, t := range e.conf.Targets {
-		err := t.Execute(source, &e.Options.Target)
+
+		if t.Prefix == "" && e.conf.Source.Prefix != "" {
+			t.Prefix = e.conf.Source.Prefix
+		}
+
+		if t.Postfix == "" && e.conf.Source.Postfix != "" {
+			t.Postfix = e.conf.Source.Postfix
+		}
+
+		err := t.Execute(e.conf.Source.Output, &e.Options.Target)
 		if err != nil {
 			fmt.Printf("Something went wrong in target \"%v\" :\n", id)
 			fmt.Printf("%v\n\n", err)

--- a/pkg/engine/source/main.go
+++ b/pkg/engine/source/main.go
@@ -26,7 +26,7 @@ type Spec interface {
 }
 
 // Execute execute actions defined by the source configuration
-func (s *Source) Execute() (string, error) {
+func (s *Source) Execute() error {
 
 	fmt.Printf("\n\n%s:\n", strings.ToTitle("Source"))
 	fmt.Printf("%s\n\n", strings.Repeat("=", len("Source")+1))
@@ -42,7 +42,7 @@ func (s *Source) Execute() (string, error) {
 		err := mapstructure.Decode(s.Spec, &g)
 
 		if err != nil {
-			return "", err
+			return err
 		}
 
 		spec = &g
@@ -52,7 +52,7 @@ func (s *Source) Execute() (string, error) {
 		err := mapstructure.Decode(s.Spec, &c)
 
 		if err != nil {
-			return "", err
+			return err
 		}
 
 		spec = &c
@@ -62,7 +62,7 @@ func (s *Source) Execute() (string, error) {
 		err := mapstructure.Decode(s.Spec, &m)
 
 		if err != nil {
-			return "", err
+			return err
 		}
 
 		spec = &m
@@ -72,21 +72,21 @@ func (s *Source) Execute() (string, error) {
 		err := mapstructure.Decode(s.Spec, &d)
 
 		if err != nil {
-			return "", err
+			return err
 		}
 
 		spec = &d
 
 	default:
-		return "", fmt.Errorf("⚠ Don't support source kind: %v", s.Kind)
+		return fmt.Errorf("⚠ Don't support source kind: %v", s.Kind)
 	}
 
 	output, err = spec.Source()
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	s.Output = s.Prefix + output + s.Postfix
+	s.Output = output
 
-	return s.Output, nil
+	return nil
 }

--- a/pkg/engine/target/main.go
+++ b/pkg/engine/target/main.go
@@ -13,10 +13,12 @@ import (
 
 // Target defines which file needs to be updated based on source output
 type Target struct {
-	Name string
-	Kind string
-	Spec interface{}
-	Scm  map[string]interface{}
+	Name    string
+	Kind    string
+	Prefix  string
+	Postfix string
+	Spec    interface{}
+	Scm     map[string]interface{}
 }
 
 // Spec is an interface which offers common function to manipulate targets.
@@ -104,7 +106,10 @@ func (t *Target) Execute(source string, o *Options) error {
 		scm.Clone()
 	}
 
-	changed, message, err := spec.Target(source, t.Name, scm.GetDirectory())
+	changed, message, err := spec.Target(
+		t.Prefix+source+t.Postfix,
+		t.Name,
+		scm.GetDirectory())
 
 	if err != nil {
 		return err


### PR DESCRIPTION
* Allow to also specify prefix/postfix per target instead of from source
* Remove useless variables

Resolve #61
