### PR TITLE
Add helm chart source message

### DIFF
--- a/pkg/helm/chart/main.go
+++ b/pkg/helm/chart/main.go
@@ -97,6 +97,13 @@ func (c *Chart) Source() (string, error) {
 		return "", err
 	}
 
+	if e.Version != "" {
+		fmt.Printf("\u2714 Helm Chart '%s' version '%v' is founded from repository %s\n",
+			c.Name,
+			e.Version,
+			c.URL)
+	}
+
 	return e.Version, nil
 
 }


### PR DESCRIPTION
Resolve #63 

```
SOURCE:
=======

✔ Helm Chart 'jenkins' version '2.3.0' is founded from repository https://kubernetes-charts.storage.googleapis.com


```