### PR TITLE
Use YAML in condition as well

### DIFF
--- a/pkg/engine/condition/main.go
+++ b/pkg/engine/condition/main.go
@@ -2,11 +2,15 @@ package condition
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/olblak/updateCli/pkg/docker"
 	"github.com/olblak/updateCli/pkg/helm/chart"
 	"github.com/olblak/updateCli/pkg/maven"
+	"github.com/olblak/updateCli/pkg/scm"
+	"github.com/olblak/updateCli/pkg/yaml"
 )
 
 // Condition defines which condition needs to be met
@@ -15,15 +19,46 @@ type Condition struct {
 	Name string
 	Kind string
 	Spec interface{}
+	Scm  map[string]interface{}
 }
 
-// Spec is an interface to test if condition is met
+// Spec is an interface that test if condition is met
 type Spec interface {
 	Condition() (bool, error)
 }
 
 // Execute tests if a specific condition is true
 func (c *Condition) Execute(source string) (bool, error) {
+
+	var s scm.Scm
+
+	pwd, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+
+	// By default workingDir is set to local directory
+	workingDir := filepath.Dir(pwd)
+
+	// If scm is defined then clone the repository
+	if len(c.Scm) > 0 {
+		s, err = scm.Unmarshal(c.Scm)
+		if err != nil {
+			return false, err
+		}
+
+		err = s.Init(source, c.Name)
+
+		defer s.Clean()
+
+		if err != nil {
+			return false, err
+		}
+
+		s.Clone()
+
+		workingDir = s.GetDirectory()
+	}
 
 	var spec Spec
 
@@ -67,11 +102,24 @@ func (c *Condition) Execute(source string) (bool, error) {
 
 		spec = &ch
 
+	case "yaml":
+		var y yaml.Yaml
+
+		err := mapstructure.Decode(c.Spec, &y)
+
+		if err != nil {
+			return false, err
+		}
+
+		y.Path = workingDir
+
+		spec = &y
+
 	default:
-		return false, fmt.Errorf("⚠ Don't support condition: %v", c.Kind)
+		return false, fmt.Errorf("Don't support condition: %v", c.Kind)
 	}
 
-	ok, err := spec.Condition()
+	ok, err = spec.Condition()
 
 	if err != nil {
 		return false, err

--- a/pkg/engine/target/main.go
+++ b/pkg/engine/target/main.go
@@ -23,33 +23,7 @@ type Target struct {
 
 // Spec is an interface which offers common function to manipulate targets.
 type Spec interface {
-	GetFile() string
-	Target(source, name string, workDir string) (bool, string, error)
-}
-
-// Unmarshal parses target spec and return its Spec interface
-func (t *Target) Unmarshal() (Spec, error) {
-
-	var spec Spec
-
-	switch t.Kind {
-
-	case "yaml":
-		var y yaml.Yaml
-
-		err := mapstructure.Decode(t.Spec, &y)
-
-		if err != nil {
-			return nil, err
-		}
-
-		spec = &y
-
-	default:
-		return nil, fmt.Errorf("⚠ Don't support target: %v", t.Kind)
-	}
-
-	return spec, nil
+	Target() (bool, error)
 }
 
 // Check verifies if mandatory Targets parameters are provided and return false if not.
@@ -72,44 +46,76 @@ func (t *Target) Check() (bool, error) {
 // Execute applies a specific target configuration
 func (t *Target) Execute(source string, o *Options) error {
 
-	_, err := t.Check()
+	var s scm.Scm
+	var message string
+	var file string
+
+	pwd, err := os.Executable()
 	if err != nil {
-		return err
+		panic(err)
 	}
 
-	scm, err := scm.Unmarshal(t.Scm)
-	if err != nil {
-		return err
+	workingDir := filepath.Dir(pwd)
+
+	if len(t.Scm) > 0 {
+		_, err := t.Check()
+		if err != nil {
+			return err
+		}
+
+		s, err = scm.Unmarshal(t.Scm)
+		if err != nil {
+			return err
+		}
+
+		err = s.Init(source, t.Name)
+
+		if o.Clean {
+			defer s.Clean()
+		}
+
+		if err != nil {
+			return err
+		}
+
+		s.Clone()
+
+		workingDir = s.GetDirectory()
+
 	}
 
-	spec, err := t.Unmarshal()
+	var spec Spec
 
-	if err != nil {
-		return err
+	switch t.Kind {
+
+	case "yaml":
+		var y yaml.Yaml
+
+		err := mapstructure.Decode(t.Spec, &y)
+
+		if err != nil {
+			return err
+		}
+
+		y.Value = t.Prefix + source + t.Postfix
+
+		y.Path = workingDir
+
+		file = y.File
+		message = fmt.Sprintf("[updatecli] Update %s version to %v\n\nKey '%s', from file '%v', was updated to '%s'\n",
+			t.Name,
+			y.Value,
+			y.Key,
+			y.File,
+			y.Key)
+
+		spec = &y
+
+	default:
+		return fmt.Errorf("Don't support target: %v", t.Kind)
 	}
 
-	err = scm.Init(source, t.Name)
-
-	if o.Clean {
-		defer scm.Clean()
-	}
-
-	if err != nil {
-		return err
-	}
-
-	file := spec.GetFile()
-
-	path := filepath.Join(scm.GetDirectory(), file)
-
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		scm.Clone()
-	}
-
-	changed, message, err := spec.Target(
-		t.Prefix+source+t.Postfix,
-		t.Name,
-		scm.GetDirectory())
+	changed, err := spec.Target()
 
 	if err != nil {
 		return err
@@ -120,12 +126,15 @@ func (t *Target) Execute(source string, o *Options) error {
 			return fmt.Errorf("Target has no change message")
 		}
 
-		if o.Commit {
-			scm.Add(file)
-			scm.Commit(file, message)
-		}
-		if o.Push {
-			scm.Push()
+		if len(t.Scm) > 0 {
+
+			if o.Commit {
+				s.Add(file)
+				s.Commit(file, message)
+			}
+			if o.Push {
+				s.Push()
+			}
 		}
 	}
 

--- a/pkg/scm/main.go
+++ b/pkg/scm/main.go
@@ -23,7 +23,7 @@ type Scm interface {
 func Unmarshal(scm map[string]interface{}) (Scm, error) {
 	var s Scm
 	if len(scm) != 1 {
-		return nil, fmt.Errorf("Target scm: Only one scm can be provided [git,github]")
+		return nil, fmt.Errorf("Target scm: Only one scm can be provided between git and github")
 	}
 
 	for key, value := range scm {

--- a/updateCli.d/grafana-loki.tpl
+++ b/updateCli.d/grafana-loki.tpl
@@ -1,0 +1,45 @@
+source:
+  kind: helmChart
+  spec:
+    url: https://grafana.github.io/loki/charts
+    name: loki
+
+conditions:
+  exist:
+    name: "Loki helm chart available on Registry"
+    kind: helmChart
+    spec:
+      url: https://grafana.github.io/loki/charts
+      name: loki
+  isNameGrafana:
+    kind: yaml
+    spec:
+      file: "helmfile.d/loki.yaml"
+      key: "releases[0].name"
+      value: "grafana"
+    scm:
+      github:
+        user: "updatecli"
+        email: "updatecli@olblak.com"
+        owner: "jenkins-infra"
+        repository: "charts"
+        token: {{ requiredEnv "GITHUB_TOKEN" }}
+        username: "olblak"
+        branch: "master"
+
+targets:
+  chartVersion:
+    name: "grafana/loki Helm Chart"
+    kind: yaml
+    spec:
+      file: "helmfile.d/loki.yaml"
+      key: "releases[0].version"
+    scm:
+      github:
+        user: "updatecli"
+        email: "updatecli@olblak.com"
+        owner: "jenkins-infra"
+        repository: "charts"
+        token: {{ requiredEnv "GITHUB_TOKEN" }}
+        username: "olblak"
+        branch: "master"

--- a/updateCli.d/jenkins-chart.tpl
+++ b/updateCli.d/jenkins-chart.tpl
@@ -1,0 +1,46 @@
+source:
+  kind: helmChart
+  spec:
+    url: https://kubernetes-charts.storage.googleapis.com
+    name: jenkins
+
+conditions:
+  exist:
+    name: "Docker Image Published on Registry"
+    kind: helmChart
+    spec:
+      url: https://kubernetes-charts.storage.googleapis.com
+      name: jenkins
+  chartDependencyIsJenkins:
+    name: "Helm Chart"
+    kind: yaml
+    spec:
+      file: "charts/jenkins/requirements.yaml"
+      key: "dependencies[0].name"
+      value: "jenkins"
+    scm:
+      github:
+        user: "updatecli"
+        email: "updatecli@olblak.com"
+        owner: "olblak"
+        repository: "charts"
+        token: {{ requiredEnv "GITHUB_TOKEN" }}
+        username: "olblak"
+        branch: "master"
+
+targets:
+  imageTag:
+    name: "Helm Chart"
+    kind: yaml
+    spec:
+      file: "charts/jenkins/requirements.yaml"
+      key: "dependencies[0].version"
+    scm:
+      github:
+        user: "updatecli"
+        email: "updatecli@olblak.com"
+        owner: "olblak"
+        repository: "charts"
+        token: {{ requiredEnv "GITHUB_TOKEN" }}
+        username: "olblak"
+        branch: "master"

--- a/updateCli.d/noYamlConditionScm.tpl
+++ b/updateCli.d/noYamlConditionScm.tpl
@@ -1,0 +1,25 @@
+source:
+  kind: helmChart
+  spec:
+    url: https://grafana.github.io/loki/charts
+    name: loki
+
+conditions:
+  isKeyExistWithCorrectValue:
+    kind: yaml
+    spec:
+      file: "updateCli.d/jenkins.yaml"
+      key: "targets.imageTag.kind"
+      value: "yaml"
+  isKeyExistWithWrongValue:
+    kind: yaml
+    spec:
+      file: "updateCli.d/jenkins.yaml"
+      key: "targets.imageTag.kind"
+      value: "wrongValueTest"
+  isKeyExistDoesntExist:
+    kind: yaml
+    spec:
+      file: "updateCli.d/jenkins.yaml"
+      key: "targets.imageTag.kindkindkind"
+      value: "doesntExistKeyCheck"


### PR DESCRIPTION
Resolve #59 
This PR refactors the way target and YAML works in order to
* Prepare the land for other targets than YAML like JSON or other formats
* Use YAML in condition as well
* Allow using YAML condition and target with or without scm definition, if no definition is specified then YAML file is read from the local path starting at the updatecli binary location.

YAML condition looks like 
```
######################
# NOYAMLCONDITIONSCM #
######################



SOURCE:
=======

...

CONDITIONS:
===========

✔ Key 'targets.imageTag.kind', from file 'updateCli.d/jenkins.yaml', is correctly set to yaml'
✗ Key 'targets.imageTag.kind', from file 'updateCli.d/jenkins.yaml', is incorrectly set to yaml and should be wrongValueTest'
✗ cannot find key 'targets.imageTag.kindkindkind' from file '/home/olblak/Project/Olblak/updatecli'

```