### PR TITLE
Search yaml target file into multiple location

### DIFF
--- a/examples/updateCli.d/docker-compose.yaml
+++ b/examples/updateCli.d/docker-compose.yaml
@@ -1,0 +1,16 @@
+source:
+  kind: dockerDigest
+  spec:
+    image: "olblak/polls"
+    tag: "latest"
+targets:
+  imageTag:
+    name: "updatecli docker image tag"
+    kind: "yaml"
+    prefix: "olblak/polls@256:"
+    spec:
+      #path: "/tt"
+      #file: "/home/olblak/Project/Jenkins-infra/polls/docker-compose.yaml"
+      file: "../../Jenkins-infra/polls/docker-compose.yamli"
+      #file: "docker-compose.yamli"
+      key: "services.api.image"

--- a/pkg/engine/target/main.go
+++ b/pkg/engine/target/main.go
@@ -99,10 +99,11 @@ func (t *Target) Execute(source string, o *Options) error {
 
 		y.Value = t.Prefix + source + t.Postfix
 
-		if dir, base, err := isFileExist(y.File); err == nil {
+		if dir, base, err := isFileExist(y.File); y.Path == "" && err == nil {
 			y.Path = dir
 			y.File = base
 		} else if !isDirectory(y.Path) {
+			fmt.Printf("Directory %s is not valid so fallback to current directory %s\n", y.Path, workingDir)
 			y.Path = workingDir
 		} else {
 			fmt.Println("Something weird happened while settings yaml directory")

--- a/pkg/engine/target/main.go
+++ b/pkg/engine/target/main.go
@@ -50,7 +50,7 @@ func (t *Target) Execute(source string, o *Options) error {
 	var message string
 	var file string
 
-	pwd, err := os.Executable()
+	pwd, err := os.Getwd()
 	if err != nil {
 		panic(err)
 	}
@@ -99,9 +99,17 @@ func (t *Target) Execute(source string, o *Options) error {
 
 		y.Value = t.Prefix + source + t.Postfix
 
-		y.Path = workingDir
+		if dir, base, err := isFileExist(y.File); err == nil {
+			y.Path = dir
+			y.File = base
+		} else if !isDirectory(y.Path) {
+			y.Path = workingDir
+		} else {
+			fmt.Println("Something weird happened while settings yaml directory")
+		}
 
 		file = y.File
+
 		message = fmt.Sprintf("[updatecli] Update %s version to %v\n\nKey '%s', from file '%v', was updated to '%s'\n",
 			t.Name,
 			y.Value,
@@ -139,4 +147,31 @@ func (t *Target) Execute(source string, o *Options) error {
 	}
 
 	return nil
+}
+
+func isFileExist(file string) (dir string, base string, err error) {
+	if _, err := os.Stat(file); err != nil {
+		return "", "", err
+	}
+
+	absolutePath, err := filepath.Abs(file)
+	if err != nil {
+		return "", "", err
+	}
+	dir = filepath.Dir(absolutePath)
+	base = filepath.Base(absolutePath)
+
+	return dir, base, err
+}
+
+func isDirectory(path string) bool {
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if info.IsDir() {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
This pr now looks YAML file into multiple locations

if a directory is not defined in the yaml configuration then it checks if the specified file exists on the disk based on the path otherwise search locally from where we run the command

I used the command `updatecli diff --config config.yaml` on the following config.yaml file to validate

.config.yaml
```
source:
  kind: dockerDigest
  spec:
    image: "olblak/polls"
    tag: "latest"
targets:
  imageTag:
    name: "updatecli docker image tag"
    kind: "yaml"
    prefix: "olblak/polls@256:"
    spec:
      #path: "/tt"
      #file: "/home/olblak/Project/Jenkins-infra/polls/docker-compose.yaml"
      file: "../../Jenkins-infra/polls/docker-compose.yamli"
      #file: "docker-compose.yamli"
      key: "services.api.image"
```