### PR TITLE
Add replace rules in source definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,26 @@ source:
 	artifactID: "jenkins-war",
 ```
 
+#### Replacer
+A List of replacer rule can be provided to modify the value retrieved from source
+
+```
+source:
+  kind: githubRelease
+  replaces: 
+    - from: "string"
+      to: ""
+    - from: "substring1"
+      to: "substring2"
+  spec:
+    owner: "Github Owner"
+    repository: "Github Repository"
+    token: "Don't commit your secrets!"
+    url: "Github Url"
+    version: "Version to fetch"
+```
+
+
 #### Prefix/Postfix
 A prefix and/or postfix can be added to any value retrieved from the source.
 This prefix/postfix will be used by 'condition' checks, then by every target unless one is explicitly defined in a target.

--- a/pkg/engine/source/main.go
+++ b/pkg/engine/source/main.go
@@ -13,11 +13,12 @@ import (
 
 // Source defines how a value is retrieved from a specific source
 type Source struct {
-	Kind    string
-	Output  string
-	Prefix  string
-	Postfix string
-	Spec    interface{}
+	Kind     string
+	Output   string
+	Prefix   string
+	Postfix  string
+	Replaces Replacers
+	Spec     interface{}
 }
 
 // Spec source is an interface to handle source spec
@@ -86,7 +87,14 @@ func (s *Source) Execute() error {
 		return err
 	}
 
-	s.Output = output
+	if len(s.Replaces) > 0 {
+		args := s.Replaces.Unmarshal()
+
+		r := strings.NewReplacer(args...)
+		s.Output = (r.Replace(output))
+	} else {
+		s.Output = output
+	}
 
 	return nil
 }

--- a/pkg/engine/source/replacer.go
+++ b/pkg/engine/source/replacer.go
@@ -1,0 +1,20 @@
+package source
+
+// Replacer is struct used to feed strings.Replacer
+type Replacer struct {
+	From string
+	To   string
+}
+
+// Replacers is an array of Replacer
+type Replacers []Replacer
+
+// Unmarshal read a struct of Replacers then return a slice of string
+func (replacers Replacers) Unmarshal() (result []string) {
+
+	for _, r := range replacers {
+		result = append(result, r.From)
+		result = append(result, r.To)
+	}
+	return result
+}

--- a/pkg/engine/source/replacer_test.go
+++ b/pkg/engine/source/replacer_test.go
@@ -1,0 +1,39 @@
+package source
+
+import (
+	"testing"
+	"reflect"
+)
+
+func TestReplacersUnmarshall(t *testing.T) {
+	dataSet := Replacers{
+		{
+			Source: "a",
+			Destination: "b",
+		},
+		{
+			Source: "c",
+			Destination: "d",
+		},
+		{
+			Source: "e",
+			Destination: "f",
+		},
+	}
+	expected := []string{ "a","b","c","d","e","f"}
+
+	got := dataSet.Unmarshal()
+
+	// Testing that we correctly get a slice of string
+	if ! reflect.DeepEqual(expected, got) {
+		t.Errorf("List of replacers is incorrect, expected '%v', got '%v'", expected, got)
+	}
+
+
+	// Testing that order matter
+	expected = []string{ "a","c","b","d","e","d"}
+
+	if reflect.DeepEqual(expected, got) {
+		t.Errorf("List of replacers is incorrect, expected '%v', got '%v'", expected, got)
+	}
+}

--- a/pkg/engine/source/replacer_test.go
+++ b/pkg/engine/source/replacer_test.go
@@ -1,37 +1,36 @@
 package source
 
 import (
-	"testing"
 	"reflect"
+	"testing"
 )
 
 func TestReplacersUnmarshall(t *testing.T) {
 	dataSet := Replacers{
 		{
 			From: "a",
-			To: "b",
+			To:   "b",
 		},
 		{
 			From: "c",
-			To: "d",
+			To:   "d",
 		},
 		{
 			From: "e",
-			To: "f",
+			To:   "f",
 		},
 	}
-	expected := []string{ "a","b","c","d","e","f"}
+	expected := []string{"a", "b", "c", "d", "e", "f"}
 
 	got := dataSet.Unmarshal()
 
 	// Testing that we correctly get a slice of string
-	if ! reflect.DeepEqual(expected, got) {
+	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("List of replacers is incorrect, expected '%v', got '%v'", expected, got)
 	}
 
-
 	// Testing that order matter
-	expected = []string{ "a","c","b","d","e","d"}
+	expected = []string{"a", "c", "b", "d", "e", "d"}
 
 	if reflect.DeepEqual(expected, got) {
 		t.Errorf("List of replacers is incorrect, expected '%v', got '%v'", expected, got)

--- a/pkg/engine/source/replacer_test.go
+++ b/pkg/engine/source/replacer_test.go
@@ -8,16 +8,16 @@ import (
 func TestReplacersUnmarshall(t *testing.T) {
 	dataSet := Replacers{
 		{
-			Source: "a",
-			Destination: "b",
+			From: "a",
+			To: "b",
 		},
 		{
-			Source: "c",
-			Destination: "d",
+			From: "c",
+			To: "d",
 		},
 		{
-			Source: "e",
-			Destination: "f",
+			From: "e",
+			To: "f",
 		},
 	}
 	expected := []string{ "a","b","c","d","e","f"}


### PR DESCRIPTION
Sometimes it happens that a source returns unwanted strings and we want to remove a sub part.
An example, the release tag from [https://github.com/Azure/azure-cli/releases](github.com/azure/azure-cli) prefix 'azure-cli-' to version name like `azure-cli-2.9.1` but the docker image tag doesn't contain that 'azure-cli-'

So to automated tag update, we need to be able to remove such strings

Signed-off-by: Olivier Vernin <olivier@vernin.me>