### PR TITLE
Retrieve and use source changelog when available

### DIFF
--- a/examples/updateCli.d/jenkins-wiki-exporter.tpl
+++ b/examples/updateCli.d/jenkins-wiki-exporter.tpl
@@ -3,7 +3,7 @@ source:
   spec:
     owner: "jenkins-infra"
     repository: "jenkins-wiki-exporter"
-    token: ""
+    token: {{ requiredEnv "GITHUB_TOKEN" }}
     username: "olblak"
     version: "latest"
 conditions:
@@ -25,7 +25,7 @@ targets:
         email: "update-bot@olblak.com"
         owner: "olblak"
         repository: "charts"
-        token: ""
+        token: {{ requiredEnv "GITHUB_TOKEN" }}
         username: "olblak"
         branch: "master"
   #appVersion:
@@ -40,7 +40,7 @@ targets:
   #      email: "updatecli@olblak.com"
   #      owner: "olblak"
   #      repository: "charts"
-  #      token: ""
+  #      token: {{ requiredEnv "GITHUB_TOKEN" }}
   #      username: "olblak"
   #      branch: "master"
   appVersion:
@@ -55,6 +55,6 @@ targets:
         email: "updatecli@olblak.com"
         owner: "olblak"
         repository: "charts"
-        token: ""
+        token: {{ requiredEnv "GITHUB_TOKEN" }}
         username: "olblak"
         branch: "master"

--- a/examples/updateCli.d/pluginsite-api.tpl
+++ b/examples/updateCli.d/pluginsite-api.tpl
@@ -37,8 +37,8 @@ targets:
         token: {{ requiredEnv "GITHUB_TOKEN" }}
         username: "olblak"
         branch: "master"
-      git:
-        url: "git@github.com:olblak/charts.git"
-        branch: "updatecli/Helm_Chart/2.3.3"
-        user: "update-bot"
-        email: "update-bot@olblak.com"
+#      git:
+#        url: "git@github.com:olblak/charts.git"
+#        branch: "updatecli/Helm_Chart/2.3.3"
+#        user: "update-bot"
+#        email: "update-bot@olblak.com"

--- a/pkg/engine/target/main.go
+++ b/pkg/engine/target/main.go
@@ -13,13 +13,14 @@ import (
 
 // Target defines which file needs to be updated based on source output
 type Target struct {
-	Name    string
-	Kind    string
-	Prefix  string
-	Postfix string
-	Spec    interface{}
-	Scm     map[string]interface{}
-	Result  string `yaml:"-"`
+	Name      string
+	Kind      string
+	Changelog string `yaml:"-"`
+	Prefix    string
+	Postfix   string
+	Spec      interface{}
+	Scm       map[string]interface{}
+	Result    string `yaml:"-"`
 }
 
 // Spec is an interface which offers common function to manipulate targets.

--- a/pkg/github/pullrequest.go
+++ b/pkg/github/pullrequest.go
@@ -42,7 +42,7 @@ func SetBody(changelog string) (body string, err error) {
 	}
 
 	err = t.Execute(buffer, params{
-		Changelog: "Update Docker Image version to 2.250"})
+		Changelog: changelog})
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fix a regression where we didn't test if the latest github release was a draft release or not
Add github release changelog to PR when changes need to be applied