### PR TITLE
Only clone git repository once

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -14,7 +14,7 @@ var (
 
 	applyCmd = &cobra.Command{
 		Use:   "apply",
-		Short: "apply checks if an updated is needed then apply the changes",
+		Short: "apply checks if an update is needed then apply the changes",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("\n%s\n\n", strings.ToTitle("Apply"))
 
@@ -34,10 +34,10 @@ var (
 )
 
 func init() {
-	applyCmd.Flags().StringVarP(&cfgFile, "config", "c", "./updateCli.yaml", "config file (default is ./updateCli.yaml)")
-	applyCmd.Flags().StringVarP(&valuesFile, "values", "v", "", "values file use for templating (required {.tpl,.tmpl} config)")
+	applyCmd.Flags().StringVarP(&cfgFile, "config", "c", "./updateCli.yaml", "Sets config file or directory. (default: './updateCli.yaml')")
+	applyCmd.Flags().StringVarP(&valuesFile, "values", "v", "", "Sets values file uses for templating (required {.tpl,.tmpl} config)")
 
-	applyCmd.Flags().BoolVarP(&applyCommit, "commit", "", true, "Commit")
-	applyCmd.Flags().BoolVarP(&applyPush, "push", "", true, "Push changes")
-	applyCmd.Flags().BoolVarP(&applyClean, "clean", "", true, "clean working directory")
+	applyCmd.Flags().BoolVarP(&applyCommit, "commit", "", true, "Record changes to the repository, '--commit=false' (default: true)")
+	applyCmd.Flags().BoolVarP(&applyPush, "push", "", true, "Update remote refs '--push=false' (default: true)")
+	applyCmd.Flags().BoolVarP(&applyClean, "clean", "", true, "Remove updatecli working directory like '--clean=false '(default: true)")
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -12,7 +12,7 @@ var (
 
 	diffCmd = &cobra.Command{
 		Use:   "diff",
-		Short: "diff shows if targets update are needed",
+		Short: "diff shows changes",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("\n%s\n\n", strings.ToTitle("Diff"))
 
@@ -32,7 +32,7 @@ var (
 )
 
 func init() {
-	diffCmd.Flags().StringVarP(&cfgFile, "config", "c", "./updateCli.yaml", "config file (default is ./updateCli.yaml)")
-	diffCmd.Flags().StringVarP(&valuesFile, "values", "v", "", "values file use for templating (required {.tpl,.tmpl} config)")
-	diffCmd.Flags().BoolVarP(&diffClean, "clean", "", true, "clean working directory")
+	diffCmd.Flags().StringVarP(&cfgFile, "config", "c", "./updateCli.yaml", "Sets config file or directory. (default: './updateCli.yaml')")
+	diffCmd.Flags().StringVarP(&valuesFile, "values", "v", "", "Sets values file uses for templating (required {.tpl,.tmpl} config)")
+	diffCmd.Flags().BoolVarP(&diffClean, "clean", "", true, "Remove updatecli working directory like '--clean=false '(default: true)")
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -8,6 +8,8 @@ import (
 )
 
 var (
+	diffClean bool
+
 	diffCmd = &cobra.Command{
 		Use:   "diff",
 		Short: "diff shows if targets update are needed",
@@ -19,7 +21,7 @@ var (
 
 			e.Options.Target.Commit = false
 			e.Options.Target.Push = false
-			e.Options.Target.Clean = true
+			e.Options.Target.Clean = diffClean
 			e.Options.Target.DryRun = true
 
 			run(
@@ -32,4 +34,5 @@ var (
 func init() {
 	diffCmd.Flags().StringVarP(&cfgFile, "config", "c", "./updateCli.yaml", "config file (default is ./updateCli.yaml)")
 	diffCmd.Flags().StringVarP(&valuesFile, "values", "v", "", "values file use for templating (required {.tpl,.tmpl} config)")
+	diffCmd.Flags().BoolVarP(&diffClean, "clean", "", true, "clean working directory")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/olblak/updateCli/pkg/engine"
 	"github.com/olblak/updateCli/pkg/reports"
 	"github.com/olblak/updateCli/pkg/result"
+	"github.com/olblak/updateCli/pkg/tmp"
 
 	"github.com/spf13/cobra"
 )
@@ -46,6 +47,15 @@ func run(command string) {
 
 	files := GetFiles(e.Options.File)
 	reports := reports.Reports{}
+	err := tmp.Create()
+	if err != nil {
+		fmt.Printf("\n\u26A0 %s\n", err)
+		os.Exit(1)
+	}
+
+	if applyClean && diffClean {
+		defer tmp.Clean()
+	}
 
 	for _, file := range files {
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,9 +21,15 @@ var (
 
 	rootCmd = &cobra.Command{
 		Use:   "updateCli",
-		Short: "updateCli is a tool to automate file updates",
+		Short: "Updatecli is a tool used to define and apply file update strategies. ",
 		Long: `
-updateCli is a tool to automate file updates based on source rule.`,
+Updatecli is a tool uses to apply file update strategies.
+It reads a yaml or a go template configuration file, then works into three stages:
+
+1. Source: Based on a rule fetch a value that will be injected in later stages.
+2. Conditions: Ensure that conditions are met based on the value retrieved during the source stage.
+3. Target: Update and publish the target files based on a value retrieved from the source stage.
+`,
 	}
 )
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -23,6 +23,6 @@ var (
 )
 
 func init() {
-	showCmd.Flags().StringVarP(&cfgFile, "config", "c", "./updateCli.yaml", "config file (default is ./updateCli.yaml)")
-	showCmd.Flags().StringVarP(&valuesFile, "values", "v", "", "values file uses for templating (required {.tpl,.tmpl} as config)")
+	showCmd.Flags().StringVarP(&cfgFile, "config", "c", "./updateCli.yaml", "Sets config file or directory. (default: './updateCli.yaml')")
+	showCmd.Flags().StringVarP(&valuesFile, "values", "v", "", "Sets values file uses for templating (required {.tpl,.tmpl} config)")
 }

--- a/pkg/engine/condition/main.go
+++ b/pkg/engine/condition/main.go
@@ -50,8 +50,6 @@ func (c *Condition) Execute(source string) (bool, error) {
 
 		err = s.Init(source, c.Name)
 
-		defer s.Clean()
-
 		if err != nil {
 			return false, err
 		}

--- a/pkg/engine/target/main.go
+++ b/pkg/engine/target/main.go
@@ -77,10 +77,6 @@ func (t *Target) Execute(source string, o *Options) (bool, error) {
 
 		err = s.Init(source, t.Name)
 
-		if o.Clean {
-			defer s.Clean()
-		}
-
 		if err != nil {
 			return false, err
 		}

--- a/pkg/git/main.go
+++ b/pkg/git/main.go
@@ -6,6 +6,7 @@ import (
 	"path"
 
 	git "github.com/olblak/updateCli/pkg/git/generic"
+	"github.com/olblak/updateCli/pkg/tmp"
 )
 
 // Git contains settings to manipulate a git repository.
@@ -36,7 +37,7 @@ func (g *Git) Init(source string, name string) error {
 
 func (g *Git) setDirectory(version string) {
 
-	directory := path.Join(os.TempDir(), "updatecli", g.URL)
+	directory := path.Join(tmp.Directory, g.URL)
 
 	if _, err := os.Stat(directory); os.IsNotExist(err) {
 

--- a/pkg/git/main.go
+++ b/pkg/git/main.go
@@ -3,6 +3,7 @@ package git
 import (
 	"fmt"
 	"os"
+	"path"
 
 	git "github.com/olblak/updateCli/pkg/git/generic"
 )
@@ -35,7 +36,7 @@ func (g *Git) Init(source string, name string) error {
 
 func (g *Git) setDirectory(version string) {
 
-	directory := fmt.Sprintf("%v/%v", os.TempDir(), g.URL)
+	directory := path.Join(os.TempDir(), "updatecli", g.URL)
 
 	if _, err := os.Stat(directory); os.IsNotExist(err) {
 

--- a/pkg/github/main.go
+++ b/pkg/github/main.go
@@ -162,7 +162,7 @@ func (g *Github) Init(source string, name string) error {
 
 func (g *Github) setDirectory(version string) {
 
-	directory := fmt.Sprintf("%v/%v/%v/%v", os.TempDir(), g.Owner, g.Repository, g.Version)
+	directory := os.path.Join(os.TempDir(), "updatecli", g.Owner, g.Repository)
 
 	if _, err := os.Stat(directory); os.IsNotExist(err) {
 

--- a/pkg/github/main.go
+++ b/pkg/github/main.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 	"time"
 
 	git "github.com/olblak/updateCli/pkg/git/generic"
+	"github.com/olblak/updateCli/pkg/tmp"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
@@ -162,7 +164,7 @@ func (g *Github) Init(source string, name string) error {
 
 func (g *Github) setDirectory(version string) {
 
-	directory := os.path.Join(os.TempDir(), "updatecli", g.Owner, g.Repository)
+	directory := path.Join(tmp.Directory, g.Owner, g.Repository)
 
 	if _, err := os.Stat(directory); os.IsNotExist(err) {
 

--- a/pkg/tmp/main.go
+++ b/pkg/tmp/main.go
@@ -1,0 +1,35 @@
+package tmp
+
+import (
+	"os"
+	"path"
+)
+
+var (
+	//Directory defines where updatecli will save temporary files like git clone.
+	Directory = path.Join(os.TempDir(), "updatecli")
+)
+
+// Clean will remove the main temporary directory used by updatecli.
+func Clean() error {
+	err := os.RemoveAll(Directory)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Create will create the main temporary directory used by updatecli
+func Create() error {
+
+	if _, err := os.Stat(Directory); os.IsNotExist(err) {
+
+		err := os.MkdirAll(Directory, 0755)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Fix #105 

This PR improve several things:
* Add a clean parameter for the diff subcommand like `updatecli diff --clean=true`
* By default delete the temporary directory content at the end of a full run instead of per strategy run, so we only clone git repositories once
* Change --clean parameter to keep or delete the main working directory instead of per repository 

This PR drastically drastically improve performances, I tested on [jenkins-infra/charts](https://github.com/jenkins-infra/chart)

Before:
`updatecli apply --config updateCli/updateCli.d --values updateCli/values.yaml  39,12s user 6,91s system 43% cpu 1:45,92 total`
After:
`updatecli apply --config updateCli/updateCli.d  --values updateCli/values.yaml   30,29s user 3,60s system 66% cpu 51,092 total
`
