### PR TITLE
Use different DOCKERHUB_TOKEN for github action

### DIFF
--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to GitHub Docker Registry
         uses: docker/login-action@v1 


### PR DESCRIPTION
This github secret conflicts with another one used for testing