### PR TITLE
Correctly retrieve docker image digest from ghcr.io.

### DIFF
--- a/pkg/plugins/docker/condition.go
+++ b/pkg/plugins/docker/condition.go
@@ -40,10 +40,9 @@ func (d *Docker) Condition(source string) (bool, error) {
 
 	if d.isDockerHub() {
 		dh := dockerhub.Docker{
-			Image:        image,
-			Tag:          d.Tag,
-			Architecture: d.Architecture,
-			Token:        d.Token,
+			Image: image,
+			Tag:   d.Tag,
+			Token: d.Token,
 		}
 
 		r = &dh
@@ -51,10 +50,9 @@ func (d *Docker) Condition(source string) (bool, error) {
 	} else if d.isQuaiIO() {
 
 		q := quay.Docker{
-			Image:        image,
-			Tag:          d.Tag,
-			Architecture: d.Architecture,
-			Token:        d.Token,
+			Image: image,
+			Tag:   d.Tag,
+			Token: d.Token,
 		}
 
 		r = &q
@@ -62,10 +60,9 @@ func (d *Docker) Condition(source string) (bool, error) {
 	} else if d.isGHCR() {
 
 		g := ghcr.Docker{
-			Image:        image,
-			Tag:          d.Tag,
-			Architecture: d.Architecture,
-			Token:        d.Token,
+			Image: image,
+			Tag:   d.Tag,
+			Token: d.Token,
 		}
 
 		r = &g
@@ -76,11 +73,10 @@ func (d *Docker) Condition(source string) (bool, error) {
 		}
 
 		dr := dockerregistry.Docker{
-			Image:        image,
-			Tag:          d.Tag,
-			Architecture: d.Architecture,
-			Hostname:     hostname,
-			Token:        d.Token,
+			Image:    image,
+			Tag:      d.Tag,
+			Hostname: hostname,
+			Token:    d.Token,
 		}
 
 		r = &dr

--- a/pkg/plugins/docker/main.go
+++ b/pkg/plugins/docker/main.go
@@ -9,10 +9,9 @@ import (
 
 // Docker contains various information to interact with a docker registry
 type Docker struct {
-	Architecture string
-	Image        string
-	Tag          string
-	Token        string
+	Image string
+	Tag   string
+	Token string
 }
 
 // Registry is an interface for every docker registry api
@@ -51,10 +50,6 @@ func (d *Docker) Check() (ok bool, err error) {
 
 	if d.Tag == "" {
 		d.Tag = "latest"
-	}
-
-	if d.Architecture == "" {
-		d.Architecture = "amd64"
 	}
 
 	return true, nil

--- a/pkg/plugins/docker/main_test.go
+++ b/pkg/plugins/docker/main_test.go
@@ -65,7 +65,7 @@ var data = []DataSet{
 		expectedCondition: true,
 		expectedHostname:  "ghcr.io",
 		expectedImage:     "olblak/updatecli",
-		expectedDigest:    "fd0a342a6df8b4ecb10b38c16a222bc3a964be1ab34547dbf116910b2184f4b9",
+		expectedDigest:    "f237aed76d3d00538d44448e8161df00d6c044f8823cc8eb9aeccc8413f5a029",
 	},
 	{
 		docker: Docker{

--- a/pkg/plugins/docker/main_test.go
+++ b/pkg/plugins/docker/main_test.go
@@ -119,16 +119,9 @@ func TestParameters(t *testing.T) {
 		t.Errorf("Minimum valid configuration provided! Expect %v, got %v", true, ok)
 	}
 
-	// Test if we correctly return the default architecture if not defined
-	expected := "amd64"
-	got := d.Architecture
-	if got != expected {
-		t.Errorf("Architecture is not configured! expected value %v, got %v", expected, got)
-	}
-
 	// Test if we correctly return the default docker hub url if not defined
-	expected = "latest"
-	got = d.Tag
+	expected := "latest"
+	got := d.Tag
 	if got != expected {
 		t.Errorf("Tag is not configured! expected %v, got %v", expected, got)
 	}

--- a/pkg/plugins/docker/registry/ghcr/main_test.go
+++ b/pkg/plugins/docker/registry/ghcr/main_test.go
@@ -15,28 +15,26 @@ var data = []DataSet{
 	{
 		docker: Docker{
 			Image: "olblak/updatecli",
+			Tag:   "v0.0.25",
+			Token: os.Getenv("GITHUB_TOKEN"),
+		},
+		expectedDigest: "786e49e87808a9808625cfca69b86e8e4e6a26d7f6199499f927633ea906676f",
+	},
+	{
+		docker: Docker{
+			Image: "olblak/updatecli",
 			Tag:   "v0.0.22",
 			Token: os.Getenv("GITHUB_TOKEN"),
 		},
-		expectedDigest: "fd0a342a6df8b4ecb10b38c16a222bc3a964be1ab34547dbf116910b2184f4b9",
+		expectedDigest: "f237aed76d3d00538d44448e8161df00d6c044f8823cc8eb9aeccc8413f5a029",
 	},
 	{
 		docker: Docker{
-			Image:        "olblak/updatecli",
-			Tag:          "v0.0.22",
-			Token:        os.Getenv("GITHUB_TOKEN"),
-			Architecture: "amd64",
+			Image: "olblak/updatecli",
+			Tag:   "v0.0.24",
+			Token: os.Getenv("GITHUB_TOKEN"),
 		},
-		expectedDigest: "fd0a342a6df8b4ecb10b38c16a222bc3a964be1ab34547dbf116910b2184f4b9",
-	},
-	{
-		docker: Docker{
-			Image:        "olblak/updatecli",
-			Tag:          "v0.0.22",
-			Token:        os.Getenv("GITHUB_TOKEN"),
-			Architecture: "arm64",
-		},
-		expectedDigest: "8c2d98213a7851b8dd8f3851f7453ab0ea5c9f92ca495882ef193466c3a92c21",
+		expectedDigest: "a0dfa59bddbaa538f40e2ef8eb7d87cc7591b3e2d725a1bec9135ed304f88053",
 	},
 	{
 		docker: Docker{
@@ -67,7 +65,7 @@ func TestDigest(t *testing.T) {
 		expected := d.expectedDigest
 
 		if got != expected {
-			t.Errorf("Docker Image %v:%v for architecture '%s', expect digest %v, got %v", d.docker.Image, d.docker.Tag, d.docker.Architecture, expected, got)
+			t.Errorf("Docker Image %v:%v, expect digest %v, got %v", d.docker.Image, d.docker.Tag, expected, got)
 		}
 	}
 }

--- a/pkg/plugins/docker/source.go
+++ b/pkg/plugins/docker/source.go
@@ -26,10 +26,9 @@ func (d *Docker) Source() (string, error) {
 
 	if d.isDockerHub() {
 		dh := dockerhub.Docker{
-			Image:        image,
-			Tag:          d.Tag,
-			Architecture: d.Architecture,
-			Token:        d.Token,
+			Image: image,
+			Tag:   d.Tag,
+			Token: d.Token,
 		}
 
 		r = &dh
@@ -37,10 +36,9 @@ func (d *Docker) Source() (string, error) {
 	} else if d.isQuaiIO() {
 
 		q := quay.Docker{
-			Image:        image,
-			Tag:          d.Tag,
-			Architecture: d.Architecture,
-			Token:        d.Token,
+			Image: image,
+			Tag:   d.Tag,
+			Token: d.Token,
 		}
 
 		r = &q
@@ -48,10 +46,9 @@ func (d *Docker) Source() (string, error) {
 	} else if d.isGHCR() {
 
 		g := ghcr.Docker{
-			Image:        image,
-			Tag:          d.Tag,
-			Architecture: d.Architecture,
-			Token:        d.Token,
+			Image: image,
+			Tag:   d.Tag,
+			Token: d.Token,
 		}
 
 		r = &g
@@ -62,11 +59,10 @@ func (d *Docker) Source() (string, error) {
 		}
 
 		dr := dockerregistry.Docker{
-			Image:        image,
-			Tag:          d.Tag,
-			Architecture: d.Architecture,
-			Hostname:     hostname,
-			Token:        d.Token,
+			Image:    image,
+			Tag:      d.Tag,
+			Hostname: hostname,
+			Token:    d.Token,
 		}
 
 		r = &dr


### PR DESCRIPTION
Correctly retrieve docker image digest from ghcr.io.

This PR also removes the architecture setting. I can't find a reliable way to test if a docker image exists for a specific architecture so I prefer to remove this option to avoid any confusion.

Fix #124 

Signed-off-by: Olivier Vernin <olivier@vernin.me>