### PR TITLE
Correctly build updatecli from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,13 @@ COPY . .
 
 RUN go get -d -v ./...
 
-RUN go build -v -a -o bin/updateCli
+RUN \
+  go build -v -a \
+  -ldflags "-w -s \
+    -X \"github.com/olblak/updateCli/pkg/core/version.BuildTime=`date -R`\" \
+    -X \"github.com/olblak/updateCli/pkg/core/version.GoVersion=`go version`\" \
+    -X \"github.com/olblak/updateCli/pkg/core/version.Version=`git describe --tags`\""\
+  -o bin/updateCli
 
 ###
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 .PHONY: build
 
-BUILD_DATE=`date -R`
+BUILD_DATE=$(shell date -R)
 VERSION=$(shell git describe --tags)
 GOVERSION=$(shell go version)
+
+DOCKER_IMAGE=olblak/updatecli
+DOCKER_TAG=$(VERSION)
 
 build:
 	echo $(VERSION)
@@ -30,7 +33,13 @@ version:
 	./bin/updatecli version
 
 docker.build:
-	docker build -t $(DOCKER_IMAGE):$(DOCKER_TAG) -t $(DOCKER_IMAGE):latest .
+	docker build \
+		-t "$(DOCKER_IMAGE):$(DOCKER_TAG)" \
+		-t "$(DOCKER_IMAGE):latest" \
+		-t "ghcr.io/$(DOCKER_IMAGE):$(DOCKER_TAG)" \
+		-t "ghcr.io/$(DOCKER_IMAGE):latest" \
+		-f Dockerfile \
+		.
 
 docker.run:
 	docker run -i -t --rm --name updateCli $(DOCKER_IMAGE):$(DOCKER_TAG) --help
@@ -42,6 +51,8 @@ docker.test:
 docker.push:
 	docker push $(DOCKER_IMAGE):$(DOCKER_TAG)
 	docker push $(DOCKER_IMAGE):latest
+	docker push ghcr.io/$(DOCKER_IMAGE):$(DOCKER_TAG)
+	docker push ghcr.io/$(DOCKER_IMAGE):latest
 
 display: echo $(DOCKER_TAG)
 


### PR DESCRIPTION
This PR correctly set variable that contains version information like
```
VERSION

Application:	v0.0.25-7-gb292cf8
Golang     :	1.15.5 linux/amd64
Build Time :	Sun, 22 Nov 2020 13:53:57 +0000
```
 
Instead of the current broken situation that return nothing like 
`docker run olblak/updatecli:v0.0.24 version` returns
```
VERSION


Application:	

Build Time :	
```

Signed-off-by: Olivier Vernin <olivier@vernin.me>