### PR TITLE
Git function return errors instead of just displaying them

### DIFF
--- a/pkg/core/engine/target/main.go
+++ b/pkg/core/engine/target/main.go
@@ -119,11 +119,23 @@ func (t *Target) Run(source string, o *Options) (changed bool, err error) {
 			if len(t.Scm) > 0 {
 
 				if o.Commit {
-					s.Add(files)
-					s.Commit(message)
+					err := s.Add(files)
+
+					if err != nil {
+						return changed, err
+					}
+
+					err = s.Commit(message)
+					if err != nil {
+						return changed, err
+					}
+
 				}
 				if o.Push {
-					s.Push()
+					err := s.Push()
+					if err != nil {
+						return changed, err
+					}
 				}
 			}
 		}

--- a/pkg/core/scm/main.go
+++ b/pkg/core/scm/main.go
@@ -10,14 +10,14 @@ import (
 
 // Scm is an interface that offers common functions for a source control manager like git or github
 type Scm interface {
-	Add(files []string)
-	Clone() string
-	Checkout()
+	Add(files []string) error
+	Clone() (string, error)
+	Checkout() error
 	GetDirectory() (directory string)
 	Init(source string, name string) error
-	Push()
-	Commit(message string)
-	Clean()
+	Push() error
+	Commit(message string) error
+	Clean() error
 }
 
 // Unmarshal parses a scm struct like git or github and returns a scm interface

--- a/pkg/plugins/git/generic/main.go
+++ b/pkg/plugins/git/generic/main.go
@@ -261,7 +261,7 @@ func Push(username, password, workingDir string) error {
 		localBranch))
 
 	if err := refspec.Validate(); err != nil {
-		fmt.Println(err)
+		return err
 	}
 
 	// Only push one branch at a time
@@ -272,8 +272,9 @@ func Push(username, password, workingDir string) error {
 			refspec,
 		},
 	})
+
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
 
 	fmt.Printf("\n")

--- a/pkg/plugins/git/scm.go
+++ b/pkg/plugins/git/scm.go
@@ -8,21 +8,23 @@ import (
 )
 
 // Add run `git add`.
-func (g *Git) Add(files []string) {
+func (g *Git) Add(files []string) error {
 
 	err := git.Add(files, g.GetDirectory())
 
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
+	return nil
 }
 
 // Checkout create and then uses a temporary git branch.
-func (g *Git) Checkout() {
+func (g *Git) Checkout() error {
 	err := git.Checkout(g.Branch, g.remoteBranch, g.GetDirectory())
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
+	return nil
 }
 
 // GetDirectory returns the working git directory.
@@ -31,12 +33,16 @@ func (g *Git) GetDirectory() (directory string) {
 }
 
 // Clean removes the current git repository from local storage.
-func (g *Git) Clean() {
-	os.RemoveAll(g.Directory) // clean up
+func (g *Git) Clean() error {
+	err := os.RemoveAll(g.Directory) // clean up
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Clone run `git clone`.
-func (g *Git) Clone() string {
+func (g *Git) Clone() (string, error) {
 
 	g.setDirectory()
 
@@ -48,15 +54,16 @@ func (g *Git) Clone() string {
 
 	if err != nil {
 		fmt.Println(err)
+		return "", err
 	}
 
 	g.Checkout()
 
-	return g.Directory
+	return g.Directory, nil
 }
 
 // Commit run `git commit`.
-func (g *Git) Commit(message string) {
+func (g *Git) Commit(message string) error {
 
 	err := git.Commit(
 		g.User,
@@ -65,9 +72,9 @@ func (g *Git) Commit(message string) {
 		g.GetDirectory())
 
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
-
+	return nil
 }
 
 // Init set Git parameters if needed.
@@ -79,7 +86,7 @@ func (g *Git) Init(source string, name string) error {
 }
 
 // Push run `git push`.
-func (g *Git) Push() {
+func (g *Git) Push() error {
 
 	err := git.Push(
 		g.Username,
@@ -87,9 +94,10 @@ func (g *Git) Push() {
 		g.GetDirectory())
 
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
 
 	fmt.Printf("\n")
+	return nil
 
 }

--- a/pkg/plugins/github/main.go
+++ b/pkg/plugins/github/main.go
@@ -76,7 +76,7 @@ func (g *Github) setDirectory() {
 }
 
 // OpenPullRequest creates a new pull request.
-func (g *Github) OpenPullRequest() {
+func (g *Github) OpenPullRequest() error {
 
 	/*
 		mutation($input: CreatePullRequestInput!){
@@ -116,17 +116,11 @@ func (g *Github) OpenPullRequest() {
 	bodyPR, err := SetBody(g.PullRequestDescription)
 
 	if err != nil {
-		fmt.Println(err)
-		return
+		return err
 	}
 
 	if ok, url, err := g.isPRExist(); ok && err == nil {
-		fmt.Printf("Pull Request titled '%v' already exist at\n\t%s\n", title, url)
-		return
-	}
-
-	if err != nil {
-		fmt.Println(err)
+		fmt.Printf("Pull request titled '%v' already exist at\n\t%s\n", title, url)
 	}
 
 	input := githubv4.CreatePullRequestInput{
@@ -141,7 +135,11 @@ func (g *Github) OpenPullRequest() {
 
 	err = client.Mutate(context.Background(), &mutation, input, nil)
 
-	return
+	if err != nil {
+		return err
+	}
+
+	return nil
 
 }
 

--- a/pkg/plugins/github/scm.go
+++ b/pkg/plugins/github/scm.go
@@ -26,12 +26,16 @@ func (g *Github) GetDirectory() (directory string) {
 }
 
 // Clean deletes github working directory.
-func (g *Github) Clean() {
-	os.RemoveAll(g.Directory)
+func (g *Github) Clean() error {
+	err := os.RemoveAll(g.Directory)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Clone run `git clone`.
-func (g *Github) Clone() string {
+func (g *Github) Clone() (string, error) {
 
 	URL := fmt.Sprintf("https://github.com/%v/%v.git",
 		g.Owner,
@@ -42,52 +46,60 @@ func (g *Github) Clone() string {
 	err := git.Clone(g.Username, g.Token, URL, g.GetDirectory())
 
 	if err != nil {
-		fmt.Println(err)
+		return "", err
 	}
 
 	err = git.Checkout(g.Branch, g.remoteBranch, g.GetDirectory())
 
 	if err != nil {
-		fmt.Println(err)
+		return "", err
 	}
 
-	return g.Directory
+	return g.Directory, nil
 }
 
 // Commit run `git commit`.
-func (g *Github) Commit(message string) {
+func (g *Github) Commit(message string) error {
 	err := git.Commit(g.User, g.Email, message, g.GetDirectory())
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
+	return nil
 }
 
 // Checkout create and then uses a temporary git branch.
-func (g *Github) Checkout() {
+func (g *Github) Checkout() error {
 	err := git.Checkout(g.Branch, g.remoteBranch, g.Directory)
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
+	return nil
 }
 
 // Add run `git add`.
-func (g *Github) Add(files []string) {
+func (g *Github) Add(files []string) error {
 
 	err := git.Add(files, g.Directory)
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
+	return nil
 }
 
 // Push run `git push` then open a pull request on Github if not already created.
-func (g *Github) Push() {
+func (g *Github) Push() error {
 
 	err := git.Push(g.Username, g.Token, g.GetDirectory())
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
 
 	fmt.Printf("\n")
 
-	g.OpenPullRequest()
+	err = g.OpenPullRequest()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
Because we didn't exit function , related to git, in case of errors, we had situations where a git push command would fail but then it would try to open a pr instead of just exiting. This should be handled now

Signed-off-by: Olivier Vernin <olivier@vernin.me>