### PR TITLE
Add source YAML

### DIFF
--- a/pkg/core/engine/source/main.go
+++ b/pkg/core/engine/source/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/olblak/updateCli/pkg/plugins/github"
 	"github.com/olblak/updateCli/pkg/plugins/helm/chart"
 	"github.com/olblak/updateCli/pkg/plugins/maven"
+	"github.com/olblak/updateCli/pkg/plugins/yaml"
 )
 
 // Source defines how a value is retrieved from a specific source
@@ -88,6 +89,16 @@ func (s *Source) Execute() error {
 		}
 
 		spec = &d
+
+	case "yaml":
+		y := yaml.Yaml{}
+		err := mapstructure.Decode(s.Spec, &y)
+
+		if err != nil {
+			return err
+		}
+
+		spec = &y
 
 	default:
 		return fmt.Errorf("⚠ Don't support source kind: %v", s.Kind)

--- a/pkg/core/engine/source/main.go
+++ b/pkg/core/engine/source/main.go
@@ -2,9 +2,12 @@ package source
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/olblak/updateCli/pkg/core/scm"
 	"github.com/olblak/updateCli/pkg/plugins/docker"
 	"github.com/olblak/updateCli/pkg/plugins/github"
 	"github.com/olblak/updateCli/pkg/plugins/helm/chart"
@@ -22,12 +25,13 @@ type Source struct {
 	Postfix   string
 	Replaces  Replacers
 	Spec      interface{}
+	Scm       map[string]interface{}
 	Result    string `yaml:"-"` // Ignore this key field when unmarshalling yaml file
 }
 
 // Spec source is an interface to handle source spec
 type Spec interface {
-	Source() (string, error)
+	Source(workingDir string) (string, error)
 }
 
 // Changelog is an interface to retrieve changelog description
@@ -44,67 +48,48 @@ func (s *Source) Execute() error {
 	var output string
 	var err error
 
-	var spec Spec
-	var changelog Changelog
+	spec, changelog, err := s.Unmarshal()
 
-	switch s.Kind {
-	case "githubRelease":
-		g := github.Github{}
-		err := mapstructure.Decode(s.Spec, &g)
-
-		if err != nil {
-			return err
-		}
-
-		spec = &g
-		changelog = &g
-
-	case "helmChart":
-		c := chart.Chart{}
-		err := mapstructure.Decode(s.Spec, &c)
-
-		if err != nil {
-			return err
-		}
-
-		spec = &c
-		changelog = &c
-
-	case "maven":
-		m := maven.Maven{}
-		err := mapstructure.Decode(s.Spec, &m)
-
-		if err != nil {
-			return err
-		}
-
-		spec = &m
-
-	case "dockerDigest":
-		d := docker.Docker{}
-		err := mapstructure.Decode(s.Spec, &d)
-
-		if err != nil {
-			return err
-		}
-
-		spec = &d
-
-	case "yaml":
-		y := yaml.Yaml{}
-		err := mapstructure.Decode(s.Spec, &y)
-
-		if err != nil {
-			return err
-		}
-
-		spec = &y
-
-	default:
-		return fmt.Errorf("⚠ Don't support source kind: %v", s.Kind)
+	if err != nil {
+		return err
 	}
 
-	output, err = spec.Source()
+	workingDir := ""
+
+	if len(s.Scm) > 0 {
+
+		SCM, err := scm.Unmarshal(s.Scm)
+
+		if err != nil {
+			return err
+		}
+
+		err = SCM.Init("", workingDir)
+
+		if err != nil {
+			return err
+		}
+
+		err = SCM.Checkout()
+
+		if err != nil {
+			return err
+		}
+
+		workingDir = SCM.GetDirectory()
+
+	} else if len(s.Scm) == 0 {
+
+		pwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		workingDir = filepath.Dir(pwd)
+	}
+
+	output, err = spec.Source(workingDir)
+
 	if err != nil {
 		return err
 	}
@@ -138,4 +123,66 @@ func (s *Source) Execute() error {
 	}
 
 	return nil
+}
+
+// Unmarshal decode a source spec and returned its typed content
+func (s *Source) Unmarshal() (spec Spec, changelog Changelog, err error) {
+	switch s.Kind {
+	case "githubRelease":
+		g := github.Github{}
+		err := mapstructure.Decode(s.Spec, &g)
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		spec = &g
+		changelog = &g
+
+	case "helmChart":
+		c := chart.Chart{}
+		err := mapstructure.Decode(s.Spec, &c)
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		spec = &c
+		changelog = &c
+
+	case "maven":
+		m := maven.Maven{}
+		err := mapstructure.Decode(s.Spec, &m)
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		spec = &m
+
+	case "dockerDigest":
+		d := docker.Docker{}
+		err := mapstructure.Decode(s.Spec, &d)
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		spec = &d
+
+	case "yaml":
+		y := yaml.Yaml{}
+		err := mapstructure.Decode(s.Spec, &y)
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		spec = &y
+
+	default:
+		return nil, nil, fmt.Errorf("⚠ Don't support source kind: %v", s.Kind)
+	}
+	return spec, changelog, nil
+
 }

--- a/pkg/plugins/docker/main_test.go
+++ b/pkg/plugins/docker/main_test.go
@@ -156,7 +156,7 @@ func TestCondition(t *testing.T) {
 func TestSource(t *testing.T) {
 	// Test if existing return the correct digest
 	for _, d := range data {
-		got, _ := d.docker.Source()
+		got, _ := d.docker.Source("")
 		expected := d.expectedDigest
 		if got != expected {
 			t.Errorf("Docker Image %v:%v expect digest %v, got %v", d.docker.Image, d.docker.Tag, expected, got)

--- a/pkg/plugins/docker/source.go
+++ b/pkg/plugins/docker/source.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Source retrieve docker image tag digest from a registry
-func (d *Docker) Source() (string, error) {
+func (d *Docker) Source(workingDir string) (string, error) {
 
 	hostname, image, err := parseImage(d.Image)
 

--- a/pkg/plugins/github/source.go
+++ b/pkg/plugins/github/source.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Source retrieves a specific version tag from Github Releases.
-func (g *Github) Source() (string, error) {
+func (g *Github) Source(workingDir string) (string, error) {
 
 	_, err := g.Check()
 	if err != nil {

--- a/pkg/plugins/helm/chart/main_test.go
+++ b/pkg/plugins/helm/chart/main_test.go
@@ -78,7 +78,7 @@ func TestSource(t *testing.T) {
 	}
 
 	for _, d := range set {
-		got, _ := d.chart.Source()
+		got, _ := d.chart.Source("")
 
 		if got != d.expected {
 			t.Errorf("%v is published! latest expected version %v, got %v", d.chart.Name, d.expected, got)

--- a/pkg/plugins/helm/chart/source.go
+++ b/pkg/plugins/helm/chart/source.go
@@ -7,7 +7,8 @@ import (
 )
 
 // Source return the latest version
-func (c *Chart) Source() (string, error) {
+func (c *Chart) Source(workingDir string) (string, error) {
+
 	URL := fmt.Sprintf("%s/index.yaml", c.URL)
 
 	req, err := http.NewRequest("GET", URL, nil)

--- a/pkg/plugins/maven/main_test.go
+++ b/pkg/plugins/maven/main_test.go
@@ -1,6 +1,8 @@
 package maven
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestCondition(t *testing.T) {
 	// Test if existing image tag return true
@@ -43,7 +45,7 @@ func TestSource(t *testing.T) {
 		ArtifactID: "wikitext.core",
 	}
 
-	got, _ := m.Source()
+	got, _ := m.Source("")
 	expected := "1.7.4.v20130429"
 	if got != expected {
 		t.Errorf("Latest version published expected is %v, got %v", expected, got)
@@ -58,7 +60,7 @@ func TestSource(t *testing.T) {
 		Version:    "0.3",
 	}
 
-	got, _ = m.Source()
+	got, _ = m.Source("")
 	expected = "2.21"
 	if got == expected {
 		t.Errorf("Latest version published expected is %v, got %v", expected, got)

--- a/pkg/plugins/maven/source.go
+++ b/pkg/plugins/maven/source.go
@@ -9,7 +9,8 @@ import (
 )
 
 // Source return the latest version
-func (m *Maven) Source() (string, error) {
+func (m *Maven) Source(workingDir string) (string, error) {
+
 	URL := fmt.Sprintf("https://%s/%s/%s/%s/maven-metadata.xml",
 		m.URL,
 		m.Repository,

--- a/pkg/plugins/yaml/source.go
+++ b/pkg/plugins/yaml/source.go
@@ -2,7 +2,6 @@ package yaml
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -10,13 +9,8 @@ import (
 )
 
 // Source return the latest version
-func (y *Yaml) Source() (string, error) {
+func (y *Yaml) Source(workingDir string) (string, error) {
 	// By default workingDir is set to local directory
-	pwd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-	workingDir := filepath.Dir(pwd)
 
 	if y.Value != "" {
 		fmt.Println("WARNING: Key 'Value' is not used by source YAML")
@@ -55,18 +49,14 @@ func (y *Yaml) Source() (string, error) {
 
 	valueFound, value, _ := replace(&out, strings.Split(y.Key, "."), y.Value, 1)
 
-	if !valueFound {
-		fmt.Printf("\u2717 cannot find key '%s' from file '%s'\n",
-			y.Key,
-			filepath.Join(y.Path, y.File))
-		return "", nil
-
+	if valueFound {
+		fmt.Printf("\u2714 Value '%v' found for key %v in the yaml file %v \n", value, y.Key, y.File)
+		return value, nil
 	}
 
-	fmt.Printf("\u2714 Key '%s', from file '%v', is correctly set to %s'\n",
+	fmt.Printf("\u2717 cannot find key '%s' from file '%s'\n",
 		y.Key,
-		filepath.Join(y.Path, y.File),
-		y.Value)
-	return value, nil
+		filepath.Join(y.Path, y.File))
+	return "", nil
 
 }

--- a/pkg/plugins/yaml/source.go
+++ b/pkg/plugins/yaml/source.go
@@ -1,0 +1,72 @@
+package yaml
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Source return the latest version
+func (y *Yaml) Source() (string, error) {
+	// By default workingDir is set to local directory
+	pwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	workingDir := filepath.Dir(pwd)
+
+	if y.Value != "" {
+		fmt.Println("WARNING: Key 'Value' is not used by source YAML")
+	}
+
+	if dir, base, err := isFileExist(y.File); err == nil && y.Path == "" {
+		// if no scm configuration has been provided and neither file path then we try to guess the file directory.
+		// if file name contains a path then we use it otherwise we fallback to the current path
+		y.Path = dir
+		y.File = base
+	} else if _, _, err := isFileExist(y.File); err != nil && y.Path == "" {
+
+		y.Path = workingDir
+
+	} else if y.Path != "" && !isDirectory(y.Path) {
+
+		fmt.Printf("Directory '%s' is not valid so fallback to '%s'", y.Path, workingDir)
+		y.Path = workingDir
+
+	} else {
+		return "", fmt.Errorf("Something weird happened while trying to set working directory")
+	}
+
+	data, err := y.ReadFile()
+	if err != nil {
+		return "", err
+	}
+
+	var out yaml.Node
+
+	err = yaml.Unmarshal(data, &out)
+
+	if err != nil {
+		return "", fmt.Errorf("cannot unmarshal data: %v", err)
+	}
+
+	valueFound, value, _ := replace(&out, strings.Split(y.Key, "."), y.Value, 1)
+
+	if !valueFound {
+		fmt.Printf("\u2717 cannot find key '%s' from file '%s'\n",
+			y.Key,
+			filepath.Join(y.Path, y.File))
+		return "", nil
+
+	}
+
+	fmt.Printf("\u2714 Key '%s', from file '%v', is correctly set to %s'\n",
+		y.Key,
+		filepath.Join(y.Path, y.File),
+		y.Value)
+	return value, nil
+
+}


### PR DESCRIPTION
Add source "YAML".
This change needed some refactoring on the source interface in order to fetch files from a scm repository.

The source yaml can be configured as follow

```
source:
  kind: yaml
  spec:
    file: examples/values.yaml
    key: "github.user"
  #  SCM is optional
  #scm:
  #  github:
  #    user: "{{ .github.user }}" 
  #    email: "{{ .github.email }}" 
  #    owner: "{{ .github.owner }}" 
  #    repository: "{{ .github.repository }}" 
  #    token: "{{ requiredEnv .github.token }}" 
  #    username: "{{ .github.username }}" 
  #    branch: "{{ .github.branch }}" 
```