### PR TITLE
Yaml resource can read file from http url

### DIFF
--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -143,20 +143,19 @@ func (e *Engine) Prepare() (err error) {
 
 	err = tmp.Create()
 	if err != nil {
-		fmt.Printf("\n\u26A0 %s\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	err = e.ReadConfigurations()
 
 	if err != nil {
-		fmt.Printf("\n\u26A0 %s\n", err)
+		return err
 	}
 
 	err = e.InitSCM()
 
 	if err != nil {
-		fmt.Printf("\n\u26A0 %s\n", err)
+		return err
 	}
 
 	return err

--- a/pkg/plugins/file/condition.go
+++ b/pkg/plugins/file/condition.go
@@ -11,40 +11,13 @@ import (
 // Condition test if a file content match the content provided via configuration.
 // If the configuration doesn't specify a value then it fall back to the source output
 func (f *File) Condition(source string) (bool, error) {
-	var data []byte
-	var err error
 
 	// If f.Content is not provided then we use the value returned from source
 	if len(f.Content) == 0 {
 		f.Content = source
 	}
 
-	workingDir := ""
-	if strings.HasPrefix(f.File, "https://") ||
-		strings.HasPrefix(f.File, "http://") {
-		data, err = ReadFromURL(f.File)
-
-		if err != nil {
-			return false, err
-		}
-
-	} else if strings.HasPrefix(f.File, "file://") {
-		f.File = strings.TrimPrefix(f.File, "file://")
-
-		data, err = ReadFromFile(filepath.Join(workingDir, f.File))
-
-		if err != nil {
-			return false, err
-		}
-	} else {
-		data, err = ReadFromFile(filepath.Join(workingDir, f.File))
-
-		if err != nil {
-			return false, err
-		}
-
-	}
-
+	data, err := Read(f.File, "")
 	if err != nil {
 		return false, err
 	}
@@ -64,40 +37,15 @@ func (f *File) Condition(source string) (bool, error) {
 // If the configuration doesn't specify a value then it fall back to the source output
 func (f *File) ConditionFromSCM(source string, scm scm.Scm) (bool, error) {
 
-	var data []byte
-	var err error
-
 	if len(f.Content) > 0 {
 		fmt.Println("Key content defined from updatecli configuration")
 	} else {
 		f.Content = source
 	}
 
-	workingDir := scm.GetDirectory()
-
-	if strings.HasPrefix(f.File, "https://") ||
-		strings.HasPrefix(f.File, "http://") {
-		data, err = ReadFromURL(f.File)
-
-		if err != nil {
-			return false, err
-		}
-
-	} else if strings.HasPrefix(f.File, "file://") {
-		f.File = strings.TrimPrefix(f.File, "file://")
-
-		data, err = ReadFromFile(filepath.Join(workingDir, f.File))
-
-		if err != nil {
-			return false, err
-		}
-	} else {
-		data, err = ReadFromFile(filepath.Join(workingDir, f.File))
-
-		if err != nil {
-			return false, err
-		}
-
+	data, err := Read(f.File, scm.GetDirectory())
+	if err != nil {
+		return false, err
 	}
 
 	if strings.Compare(f.Content, string(data)) == 0 {

--- a/pkg/plugins/file/helpers.go
+++ b/pkg/plugins/file/helpers.go
@@ -57,6 +57,46 @@ func ReadFromFile(file string) (data []byte, err error) {
 	return data, nil
 }
 
+// HasPrefix test if a filename uses a prefix
+func HasPrefix(filename string, prefixes []string) bool {
+
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(filename, prefix) {
+			return true
+		}
+	}
+
+	return false
+
+}
+
+// Read read file from a location then return
+// an array of byte. The location accepts multiple input
+// http/https urls "https://", file url "file://", or a simple file
+func Read(filename, workingDir string) (data []byte, err error) {
+
+	if strings.HasPrefix(filename, "https://") ||
+		strings.HasPrefix(filename, "http://") {
+		data, err = ReadFromURL(filename)
+
+		if err != nil {
+			return nil, err
+		}
+		return data, err
+
+	} else if strings.HasPrefix(filename, "file://") {
+		filename = strings.TrimPrefix(filename, "file://")
+	}
+
+	data, err = ReadFromFile(filepath.Join(workingDir, filename))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return data, err
+}
+
 // Diff return a diff like string, comparing string A and string B
 func Diff(a, b string) (result string) {
 

--- a/pkg/plugins/file/source.go
+++ b/pkg/plugins/file/source.go
@@ -2,39 +2,14 @@ package file
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
 )
 
 // Source return a file content
 func (f *File) Source(workingDir string) (string, error) {
 
-	var data []byte
-	var err error
-
-	if strings.HasPrefix(f.File, "https://") ||
-		strings.HasPrefix(f.File, "http://") {
-		data, err = ReadFromURL(f.File)
-
-		if err != nil {
-			return "", err
-		}
-
-	} else if strings.HasPrefix(f.File, "file://") {
-		f.File = strings.TrimPrefix(f.File, "file://")
-
-		data, err = ReadFromFile(filepath.Join(workingDir, f.File))
-
-		if err != nil {
-			return "", err
-		}
-	} else {
-		data, err = ReadFromFile(filepath.Join(workingDir, f.File))
-
-		if err != nil {
-			return "", err
-		}
-
+	data, err := Read(f.File, workingDir)
+	if err != nil {
+		return "", err
 	}
 
 	fmt.Printf("\u2714 Content:\n%v\n\n found from file %v \n",

--- a/pkg/plugins/yaml/main.go
+++ b/pkg/plugins/yaml/main.go
@@ -2,9 +2,6 @@ package yaml
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
 
@@ -17,57 +14,10 @@ var (
 
 // Yaml stores configuration about the file and the key value which needs to be updated.
 type Yaml struct {
-	Path  string
 	File  string
 	Key   string
+	Path  string
 	Value string
-}
-
-// ReadFile read a yaml file then return its data
-func (y *Yaml) ReadFile() (data []byte, err error) {
-
-	path := filepath.Join(y.Path, y.File)
-
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-
-	defer file.Close()
-
-	data, err = ioutil.ReadAll(file)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return data, err
-}
-
-func isFileExist(file string) (dir string, base string, err error) {
-	if _, err := os.Stat(file); err != nil {
-		return "", "", err
-	}
-
-	absolutePath, err := filepath.Abs(file)
-	if err != nil {
-		return "", "", err
-	}
-	dir = filepath.Dir(absolutePath)
-	base = filepath.Base(absolutePath)
-
-	return dir, base, err
-}
-
-func isDirectory(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	if info.IsDir() {
-		return true
-	}
-	return false
 }
 
 // isPositionKey checks if key use the array position like agents[0].

--- a/pkg/plugins/yaml/source.go
+++ b/pkg/plugins/yaml/source.go
@@ -2,9 +2,9 @@ package yaml
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
+	"github.com/olblak/updateCli/pkg/plugins/file"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,25 +16,11 @@ func (y *Yaml) Source(workingDir string) (string, error) {
 		fmt.Println("WARNING: Key 'Value' is not used by source YAML")
 	}
 
-	if dir, base, err := isFileExist(y.File); err == nil && y.Path == "" {
-		// if no scm configuration has been provided and neither file path then we try to guess the file directory.
-		// if file name contains a path then we use it otherwise we fallback to the current path
-		y.Path = dir
-		y.File = base
-	} else if _, _, err := isFileExist(y.File); err != nil && y.Path == "" {
-
-		y.Path = workingDir
-
-	} else if y.Path != "" && !isDirectory(y.Path) {
-
-		fmt.Printf("Directory '%s' is not valid so fallback to '%s'", y.Path, workingDir)
-		y.Path = workingDir
-
-	} else {
-		return "", fmt.Errorf("Something weird happened while trying to set working directory")
+	if len(y.Path) > 0 {
+		fmt.Println("WARNING: Key 'Path' is obsolete and now directly defined from file")
 	}
 
-	data, err := y.ReadFile()
+	data, err := file.Read(y.File, workingDir)
 	if err != nil {
 		return "", err
 	}
@@ -56,7 +42,7 @@ func (y *Yaml) Source(workingDir string) (string, error) {
 
 	fmt.Printf("\u2717 cannot find key '%s' from file '%s'\n",
 		y.Key,
-		filepath.Join(y.Path, y.File))
+		y.File)
 	return "", nil
 
 }


### PR DESCRIPTION
This PR refactor the file and yaml resource in order to use the same function to manipulate files.
Yaml now use the same approach than file resource by 
* Deprecating the parameter 'path', that parameter was a mistake since the beginning
* The parameter 'File' now accepted following URL 
** `https://url`, `http://`, `file://` `file://` 