### PR TITLE
Add docker.io as an alias for dockerhub registry

### DIFF
--- a/pkg/plugins/docker/main.go
+++ b/pkg/plugins/docker/main.go
@@ -63,7 +63,7 @@ func (d *Docker) isDockerHub() bool {
 		fmt.Println(err)
 	}
 
-	if hostname == "hub.docker.com" {
+	if hostname == "hub.docker.com" || hostname == "docker.io" {
 		return true
 	}
 	return false


### PR DESCRIPTION
Docker image tag from docker.io registry couldn't be found

Signed-off-by: Olivier Vernin <olivier@vernin.me>