### PR TITLE
[updatecli] Bump golangci-lint version to v1.52.2

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -29,7 +29,7 @@ jobs:
           # Required: the version of golangci-lint is required
           # and must be specified without patch version:
           # we always use the latest patch version.
-          version: v1.50
+          version: v1.52
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:


### PR DESCRIPTION



<Actions>
    <action id="288309dfdc93af4a62c54e588aecc0383d215f0b34fbce9a0c10614df3798f8a">
        <h3>[updatecli] Bump golangci-lint version to v1.52.2</h3>
        <details id="37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f">
            <summary>Update Golangci-lint version to v1.52.2</summary>
            <details>
                <summary>v1.52.2</summary>
                <pre>&#xA;Release published on the 2023-03-25 18:30:47 +0000 UTC at the url https://github.com/golangci/golangci-lint/releases/tag/v1.52.2&#xA;&#xA;## Changelog&#xA;* da04413a build(deps): bump github.com/moricho/tparallel from 0.3.0 to 0.3.1 (#3719)&#xA;* 1f4fed7c fix(pre-commit): require_serial &amp; pass_filenames (#3713)&#xA;&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<details><summary>Updatecli options</summary>
Most of Updatecli configuration is done via Updatecli manifest.
<ul>
<li>If you close this pullrequest, Updatecli will automatically reopen it, the next time it runs.</li>
<li>If you close this pullrequest, and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
</ul>
</details>

---

Action triggered automatically by [Updatecli](https://www.updatecli.io).

Feel free to report any issues at [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/issues/).
If you find this tool useful, do not hesitate to star our GitHub repository [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/stargazers) as a sign of appreciation.
Or tell us directly on our [chat](https://matrix.to/#/#Updatecli_community:gitter.im)

<img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="200" height="200">
